### PR TITLE
Agregar bloque a selección de nivel educativo en convocatorias

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/entities/gestionescolar/ConvocatoriaNivelEducativoCompl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/entities/gestionescolar/ConvocatoriaNivelEducativoCompl.java
@@ -10,9 +10,10 @@ public class ConvocatoriaNivelEducativoCompl implements Serializable {
 	private String nombreivelEnsenanza;
 	private Integer idPlan;
 	private String nombrePlan;
-	private Integer idPrograma;
-	private String nombrePrograma;
-	   private Boolean seleccionado;
+        private Integer idPrograma;
+        private String nombrePrograma;
+        private String nombreBloque;
+           private Boolean seleccionado;
 
 	    public Boolean getSeleccionado() {
 	        return seleccionado;
@@ -28,8 +29,9 @@ public class ConvocatoriaNivelEducativoCompl implements Serializable {
 	                + ", nombreNivelEnsenanza=" + nombreivelEnsenanza 
 	                + ", idPlan=" + idPlan 
 	                + ", nombrePlan=" + nombrePlan 
-	                + ", idPrograma=" + idPrograma 
-	                + ", nombrePrograma=" + nombrePrograma + "]";
+                        + ", idPrograma=" + idPrograma
+                        + ", nombrePrograma=" + nombrePrograma
+                        + ", nombreBloque=" + nombreBloque + "]";
 	    }
 	 
 	public Integer getIdNivelEnsenanza() {
@@ -65,9 +67,17 @@ public class ConvocatoriaNivelEducativoCompl implements Serializable {
 	public String getNombrePrograma() {
 		return nombrePrograma;
 	}
-	public void setNombrePrograma(String nombrePrograma) {
-		this.nombrePrograma = nombrePrograma;
-	}
+        public void setNombrePrograma(String nombrePrograma) {
+                this.nombrePrograma = nombrePrograma;
+        }
+
+        public String getNombreBloque() {
+                return nombreBloque;
+        }
+
+        public void setNombreBloque(String nombreBloque) {
+                this.nombreBloque = nombreBloque;
+        }
 	
 	
 

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/ConvocatoriaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/ConvocatoriaRepository.java
@@ -159,10 +159,11 @@ public class ConvocatoriaRepository implements IConvocatoriaRepository {
 		String consulta = "select id_plan, id_programa from des_sisi_gestor.rel_convocatoria_planesyprogramas\r\n"
 				+ "WHERE id_convocatoria = :idConvocatoria";
 		
-		String consulta2 = " SELECT cnp.id id_nivel_ensenanza, cnp.nombre nivel_ensenaza, tp.id_plan id_plan, tp.nombre plan, fdp.id_programa id_programa, fdp.nombre_tentativo programa\r\n"
-				+ "FROM tbl_planes tp\r\n"
-				+ "         INNER JOIN tbl_ficha_descriptiva_programa fdp ON fdp.id_plan = tp.id_plan AND fdp.identificador_final IS not NULL AND fdp.identificador_final != ''\r\n"
-				+ "         INNER JOIN cat_nivel_ensenanza_programa cnp ON fdp.id_nivel_programa = cnp.id\r\n"
+                String consulta2 = " SELECT cnp.id id_nivel_ensenanza, cnp.nombre nivel_ensenaza, tp.id_plan id_plan, tp.nombre plan, fdp.id_programa id_programa, fdp.nombre_tentativo programa,\r\n"
+                                + "        (SELECT mcr.nombre FROM tbl_malla_curricular mcr WHERE mcr.id = fdp.id_eje_capacitacion) bloque\r\n"
+                                + "FROM tbl_planes tp\r\n"
+                                + "         INNER JOIN tbl_ficha_descriptiva_programa fdp ON fdp.id_plan = tp.id_plan AND fdp.identificador_final IS not NULL AND fdp.identificador_final != ''\r\n"
+                                + "         INNER JOIN cat_nivel_ensenanza_programa cnp ON fdp.id_nivel_programa = cnp.id\r\n"
 				+ "         INNER JOIN tbl_malla_curricular mc ON mc.id_plan = tp.id_plan AND mc.activo =1 \r\n"
 				+ "			WHERE tp.id_plan = :idPlan AND fdp.id_programa =:idPrograma";
 		
@@ -427,11 +428,12 @@ public class ConvocatoriaRepository implements IConvocatoriaRepository {
 
 		List<ConvocatoriaNivelEducativoCompl> lista = new ArrayList<ConvocatoriaNivelEducativoCompl>();
 
-		String consulta = " SELECT cnp.id id_nivel_ensenanza, cnp.nombre nivel_ensenaza, tp.id_plan id_plan, tp.nombre plan, fdp.id_programa id_programa, fdp.nombre_tentativo programa\r\n"
-				+ "FROM tbl_planes tp\r\n"
-				+ "         INNER JOIN tbl_ficha_descriptiva_programa fdp ON fdp.id_plan = tp.id_plan AND fdp.identificador_final IS not NULL AND fdp.identificador_final != ''\r\n"
-				+ "         INNER JOIN cat_nivel_ensenanza_programa cnp ON fdp.id_nivel_programa = cnp.id\r\n"
-				+ "         INNER JOIN tbl_malla_curricular mc ON mc.id_plan = tp.id_plan AND mc.activo =1";
+                String consulta = " SELECT cnp.id id_nivel_ensenanza, cnp.nombre nivel_ensenaza, tp.id_plan id_plan, tp.nombre plan, fdp.id_programa id_programa, fdp.nombre_tentativo programa,\r\n"
+                                + "        (SELECT mcr.nombre FROM tbl_malla_curricular mcr WHERE mcr.id = fdp.id_eje_capacitacion) bloque\r\n"
+                                + "FROM tbl_planes tp\r\n"
+                                + "         INNER JOIN tbl_ficha_descriptiva_programa fdp ON fdp.id_plan = tp.id_plan AND fdp.identificador_final IS not NULL AND fdp.identificador_final != ''\r\n"
+                                + "         INNER JOIN cat_nivel_ensenanza_programa cnp ON fdp.id_nivel_programa = cnp.id\r\n"
+                                + "         INNER JOIN tbl_malla_curricular mc ON mc.id_plan = tp.id_plan AND mc.activo =1";
 
 		Query query = entityManager.createNativeQuery(consulta);
 
@@ -459,11 +461,12 @@ public class ConvocatoriaRepository implements IConvocatoriaRepository {
 		regresa.setIdPlan((Integer) obj[2]);
 		regresa.setNombrePlan(obj[3].toString());
 		regresa.setIdPrograma((Integer) obj[4]);
-		regresa.setNombrePrograma(obj[5].toString());
+                regresa.setNombrePrograma(obj[5].toString());
+                regresa.setNombreBloque(obj[6] != null ? obj[6].toString() : null);
 
-		return regresa;
-		
-	}
+                return regresa;
+
+        }
 	
 	private ConvocatoriaNivelEducativo mapeoNivel(Object[] obj) {
 

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionAprendizaje/alumnoView/editaConvocatoria2.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionAprendizaje/alumnoView/editaConvocatoria2.xhtml
@@ -115,9 +115,9 @@
 								<f:selectItem
 									itemLabel="#{sistema.obtenerTexto('gw.textos.menu.seleccionar')}"
 									itemValue="#{null}" />
-								<f:selectItems value="#{convocatoriasBean.listaNivelEducativoCompl}"
-									var="modalidad" itemLabel="#{modalidad.nombreivelEnsenanza} > #{modalidad.nombrePlan} > #{modalidad.nombrePrograma}"
-									itemValue="#{modalidad}"  />
+                                                                <f:selectItems value="#{convocatoriasBean.listaNivelEducativoCompl}"
+                                                                        var="modalidad" itemLabel="#{modalidad.nombreivelEnsenanza} > #{modalidad.nombrePlan} > #{modalidad.nombrePrograma} > #{modalidad.nombreBloque}"
+                                                                        itemValue="#{modalidad}"  />
 
 							</p:selectOneMenu >
 							<p:message for="altaNivelEducativo" display="text" />

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionAprendizaje/alumnoView/nuevaConvocatoria.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionAprendizaje/alumnoView/nuevaConvocatoria.xhtml
@@ -113,11 +113,11 @@
 
 						<p:ajax event="change" process="@this" />
 				        
-						<f:selectItems
-							value="#{convocatoriasBean.listaNivelEducativoCompl}"
-							var="modalidad"
-							itemLabel="#{modalidad.nombreivelEnsenanza} > #{modalidad.nombrePlan} > #{modalidad.nombrePrograma}"
-							itemValue="#{modalidad}" />
+                                                <f:selectItems
+                                                        value="#{convocatoriasBean.listaNivelEducativoCompl}"
+                                                        var="modalidad"
+                                                        itemLabel="#{modalidad.nombreivelEnsenanza} > #{modalidad.nombrePlan} > #{modalidad.nombrePrograma} > #{modalidad.nombreBloque}"
+                                                        itemValue="#{modalidad}" />
 					</p:selectCheckboxMenu>
 					<p:message for="altaNivelEducativo" display="text" />
 				</div>


### PR DESCRIPTION
## Summary
- agrega el atributo `nombreBloque` al DTO de nivel educativo de convocatorias
- actualiza las consultas nativas para recuperar el nombre del bloque de la malla curricular
- muestra el bloque en las listas desplegables de nivel educativo del módulo de convocatorias

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690a6d0dbcb4832f92594924ae94fcbe