### PR TITLE
Ajusta navegación de botones Altas y Bajas

### DIFF
--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/altasBajasUsuarios.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/altasBajasUsuarios.xhtml
@@ -22,56 +22,84 @@
                 <h:form id="frmAltasBajas">
                     <p:messages id="msgsAltasBajas" autoUpdate="true" closable="true" />
 
-                    <div class="row">
-                        <div class="col-md-6 col-xs-12">
-                            <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.seccion.altas')}"
-                                     styleClass="panel-primary">
-                                <div class="row">
-                                    <div class="col-md-12">
-                                        <h:outputText value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.descripcion.altas')}" />
-                                    </div>
-                                </div>
-                                <div class="row">
-                                    <div class="col-md-12 text-right">
-                                        <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaAlta')}"
-                                                         action="#{altasBajasUsuariosBean.irNuevaAlta}"
-                                                         icon="fa fa-user-plus"
-                                                         styleClass="btn btn-primary"
-                                                         ajax="false"
-                                                         rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_ALT')}" />
-                                    </div>
-                                </div>
-                            </p:panel>
+                    <ui:fragment rendered="#{empty altasBajasUsuariosBean.paginaActual}">
+                        <div class="row">
+                            <div class="col-md-6 col-xs-12">
+                                <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_ALT')">
+                                    <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.seccion.altas')}"
+                                             styleClass="panel-primary">
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <h:outputText value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.descripcion.altas')}" />
+                                            </div>
+                                        </div>
+                                        <div class="row" style="margin-top: 15px;">
+                                            <div class="col-md-12 text-right">
+                                                <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.seccion.altas')}"
+                                                                 action="#{altasBajasUsuariosBean.irNuevaAlta}"
+                                                                 ajax="false"
+                                                                 immediate="true"
+                                                                 process="@this"
+                                                                 styleClass="btn btn-primary btn-block" />
+                                            </div>
+                                        </div>
+                                    </p:panel>
+                                </sec:authorize>
+                            </div>
+                            <div class="col-md-6 col-xs-12">
+                                <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_BAJ') or hasPermission(null, 'ALT_BAJ_USR_CON')">
+                                    <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.seccion.bajas')}"
+                                             styleClass="panel-primary">
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <h:outputText value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.descripcion.bajas')}" />
+                                            </div>
+                                        </div>
+                                        <div class="row" style="margin-top: 15px;">
+                                            <div class="col-md-12 text-right">
+                                                <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.seccion.bajas')}"
+                                                                 action="#{altasBajasUsuariosBean.mostrarOpcionesBajas}"
+                                                                 ajax="true"
+                                                                 process="@this"
+                                                                 update="frmAltasBajas"
+                                                                 styleClass="btn btn-primary btn-block" />
+                                            </div>
+                                        </div>
+
+                                        <ui:fragment rendered="#{altasBajasUsuariosBean.mostrarOpcionesBajas}">
+                                            <div class="row" style="margin-top: 15px;">
+                                                <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_BAJ')">
+                                                    <div class="col-md-6 col-xs-12">
+                                                        <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaBaja')}"
+                                                                         action="#{altasBajasUsuariosBean.irNuevaBaja}"
+                                                                         ajax="false"
+                                                                         immediate="true"
+                                                                         process="@this"
+                                                                         styleClass="btn btn-primary btn-block" />
+                                                    </div>
+                                                </sec:authorize>
+                                                <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_CON')">
+                                                    <div class="col-md-6 col-xs-12" style="margin-top: 10px;">
+                                                        <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.consultarBaja')}"
+                                                                         action="#{altasBajasUsuariosBean.irConsultarBaja}"
+                                                                         ajax="false"
+                                                                         immediate="true"
+                                                                         process="@this"
+                                                                         styleClass="btn btn-primary btn-block" />
+                                                    </div>
+                                                </sec:authorize>
+                                            </div>
+                                        </ui:fragment>
+                                    </p:panel>
+                                </sec:authorize>
+                            </div>
                         </div>
-                        <div class="col-md-6 col-xs-12">
-                            <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.seccion.bajas')}"
-                                     styleClass="panel-primary">
-                                <div class="row">
-                                    <div class="col-md-12">
-                                        <h:outputText value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.descripcion.bajas')}" />
-                                    </div>
-                                </div>
-                                <div class="row">
-                                    <div class="col-md-12 text-right">
-                                        <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaBaja')}"
-                                                         action="#{altasBajasUsuariosBean.irNuevaBaja}"
-                                                         icon="fa fa-user-minus"
-                                                         styleClass="btn btn-primary"
-                                                         ajax="false"
-                                                         rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_BAJ')}" />
-                                        <p:spacer width="5" />
-                                        <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.consultarBaja')}"
-                                                         action="#{altasBajasUsuariosBean.irConsultarBaja}"
-                                                         icon="fa fa-search"
-                                                         styleClass="btn btn-default"
-                                                         ajax="false"
-                                                         rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_CON')}" />
-                                    </div>
-                                </div>
-                            </p:panel>
-                        </div>
-                    </div>
+                    </ui:fragment>
                 </h:form>
+
+                <ui:fragment rendered="#{not empty altasBajasUsuariosBean.paginaActual}">
+                    <ui:include src="#{altasBajasUsuariosBean.paginaActual}" />
+                </ui:fragment>
             </sec:authorize>
         </ui:fragment>
     </ui:define>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/altasBajasUsuarios.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/altasBajasUsuarios.xhtml
@@ -24,40 +24,60 @@
 
                     <div class="form-group">
                         <div class="row">
-                            <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_ALT')">
-                                <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaAlta')}"
-                                                 action="#{altasBajasUsuariosBean.irNuevaAlta}"
-                                                 ajax="false"
-                                                 immediate="true"
-                                                 process="@this"
-                                                 styleClass="btn btn-primary"
-                                                 style="margin-right: 15px;" />
-                            </sec:authorize>
+                            <p:outputPanel id="panelBotones" layout="block">
+                                <h:panelGroup rendered="#{!altasBajasUsuariosBean.mostrarOpcionesBajas}">
+                                    <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_ALT')">
+                                        <p:commandButton value="ALTAS"
+                                                         action="#{altasBajasUsuariosBean.irNuevaAlta}"
+                                                         ajax="false"
+                                                         immediate="true"
+                                                         process="@this"
+                                                         styleClass="btn btn-primary"
+                                                         style="width: 220px; margin-right: 15px;" />
+                                    </sec:authorize>
 
-                            <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_BAJ')">
-                                <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaBaja')}"
-                                                 action="#{altasBajasUsuariosBean.irNuevaBaja}"
-                                                 ajax="false"
-                                                 immediate="true"
-                                                 process="@this"
-                                                 styleClass="btn btn-primary"
-                                                 style="margin-right: 15px;" />
-                            </sec:authorize>
+                                    <sec:authorize
+                                        access="hasPermission(null, 'ALT_BAJ_USR_BAJ') or hasPermission(null, 'ALT_BAJ_USR_CON')">
+                                        <p:commandButton value="BAJAS"
+                                                         action="#{altasBajasUsuariosBean.mostrarOpcionesBajas}"
+                                                         ajax="false"
+                                                         immediate="true"
+                                                         process="@this"
+                                                         styleClass="btn btn-primary"
+                                                         style="width: 220px;" />
+                                    </sec:authorize>
+                                </h:panelGroup>
 
-                            <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_CON')">
-                                <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.consultarBaja')}"
-                                                 action="#{altasBajasUsuariosBean.irConsultarBaja}"
-                                                 ajax="false"
-                                                 immediate="true"
-                                                 process="@this"
-                                                 styleClass="btn btn-primary" />
-                            </sec:authorize>
+                                <h:panelGroup rendered="#{altasBajasUsuariosBean.mostrarOpcionesBajas}">
+                                    <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_BAJ')">
+                                        <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaBaja')}"
+                                                         action="#{altasBajasUsuariosBean.irNuevaBaja}"
+                                                         ajax="false"
+                                                         immediate="true"
+                                                         process="@this"
+                                                         styleClass="btn btn-primary"
+                                                         style="width: 220px; margin-right: 15px;" />
+                                    </sec:authorize>
+
+                                    <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_CON')">
+                                        <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.consultarBaja')}"
+                                                         action="#{altasBajasUsuariosBean.irConsultarBaja}"
+                                                         ajax="false"
+                                                         immediate="true"
+                                                         process="@this"
+                                                         styleClass="btn btn-primary"
+                                                         style="width: 220px;" />
+                                    </sec:authorize>
+                                </h:panelGroup>
+                            </p:outputPanel>
                         </div>
                     </div>
 
-                    <ui:fragment rendered="#{not empty altasBajasUsuariosBean.paginaActual}">
-                        <ui:include src="#{altasBajasUsuariosBean.paginaActual}" />
-                    </ui:fragment>
+                    <p:outputPanel id="panelContenido" layout="block">
+                        <ui:fragment rendered="#{not empty altasBajasUsuariosBean.paginaActual}">
+                            <ui:include src="#{altasBajasUsuariosBean.paginaActual}" />
+                        </ui:fragment>
+                    </p:outputPanel>
                 </h:form>
             </sec:authorize>
         </ui:fragment>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/altasBajasUsuarios.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/altasBajasUsuarios.xhtml
@@ -22,84 +22,43 @@
                 <h:form id="frmAltasBajas">
                     <p:messages id="msgsAltasBajas" autoUpdate="true" closable="true" />
 
-                    <ui:fragment rendered="#{empty altasBajasUsuariosBean.paginaActual}">
+                    <div class="form-group">
                         <div class="row">
-                            <div class="col-md-6 col-xs-12">
-                                <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_ALT')">
-                                    <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.seccion.altas')}"
-                                             styleClass="panel-primary">
-                                        <div class="row">
-                                            <div class="col-md-12">
-                                                <h:outputText value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.descripcion.altas')}" />
-                                            </div>
-                                        </div>
-                                        <div class="row" style="margin-top: 15px;">
-                                            <div class="col-md-12 text-right">
-                                                <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.seccion.altas')}"
-                                                                 action="#{altasBajasUsuariosBean.irNuevaAlta}"
-                                                                 ajax="false"
-                                                                 immediate="true"
-                                                                 process="@this"
-                                                                 styleClass="btn btn-primary btn-block" />
-                                            </div>
-                                        </div>
-                                    </p:panel>
-                                </sec:authorize>
-                            </div>
-                            <div class="col-md-6 col-xs-12">
-                                <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_BAJ') or hasPermission(null, 'ALT_BAJ_USR_CON')">
-                                    <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.seccion.bajas')}"
-                                             styleClass="panel-primary">
-                                        <div class="row">
-                                            <div class="col-md-12">
-                                                <h:outputText value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.descripcion.bajas')}" />
-                                            </div>
-                                        </div>
-                                        <div class="row" style="margin-top: 15px;">
-                                            <div class="col-md-12 text-right">
-                                                <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.seccion.bajas')}"
-                                                                 action="#{altasBajasUsuariosBean.mostrarOpcionesBajas}"
-                                                                 ajax="true"
-                                                                 process="@this"
-                                                                 update="frmAltasBajas"
-                                                                 styleClass="btn btn-primary btn-block" />
-                                            </div>
-                                        </div>
+                            <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_ALT')">
+                                <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaAlta')}"
+                                                 action="#{altasBajasUsuariosBean.irNuevaAlta}"
+                                                 ajax="false"
+                                                 immediate="true"
+                                                 process="@this"
+                                                 styleClass="btn btn-primary"
+                                                 style="margin-right: 15px;" />
+                            </sec:authorize>
 
-                                        <ui:fragment rendered="#{altasBajasUsuariosBean.mostrarOpcionesBajas}">
-                                            <div class="row" style="margin-top: 15px;">
-                                                <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_BAJ')">
-                                                    <div class="col-md-6 col-xs-12">
-                                                        <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaBaja')}"
-                                                                         action="#{altasBajasUsuariosBean.irNuevaBaja}"
-                                                                         ajax="false"
-                                                                         immediate="true"
-                                                                         process="@this"
-                                                                         styleClass="btn btn-primary btn-block" />
-                                                    </div>
-                                                </sec:authorize>
-                                                <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_CON')">
-                                                    <div class="col-md-6 col-xs-12" style="margin-top: 10px;">
-                                                        <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.consultarBaja')}"
-                                                                         action="#{altasBajasUsuariosBean.irConsultarBaja}"
-                                                                         ajax="false"
-                                                                         immediate="true"
-                                                                         process="@this"
-                                                                         styleClass="btn btn-primary btn-block" />
-                                                    </div>
-                                                </sec:authorize>
-                                            </div>
-                                        </ui:fragment>
-                                    </p:panel>
-                                </sec:authorize>
-                            </div>
+                            <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_BAJ')">
+                                <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaBaja')}"
+                                                 action="#{altasBajasUsuariosBean.irNuevaBaja}"
+                                                 ajax="false"
+                                                 immediate="true"
+                                                 process="@this"
+                                                 styleClass="btn btn-primary"
+                                                 style="margin-right: 15px;" />
+                            </sec:authorize>
+
+                            <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_CON')">
+                                <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.consultarBaja')}"
+                                                 action="#{altasBajasUsuariosBean.irConsultarBaja}"
+                                                 ajax="false"
+                                                 immediate="true"
+                                                 process="@this"
+                                                 styleClass="btn btn-primary" />
+                            </sec:authorize>
                         </div>
+                    </div>
+
+                    <ui:fragment rendered="#{not empty altasBajasUsuariosBean.paginaActual}">
+                        <ui:include src="#{altasBajasUsuariosBean.paginaActual}" />
                     </ui:fragment>
                 </h:form>
-
-                <ui:fragment rendered="#{not empty altasBajasUsuariosBean.paginaActual}">
-                    <ui:include src="#{altasBajasUsuariosBean.paginaActual}" />
-                </ui:fragment>
             </sec:authorize>
         </ui:fragment>
     </ui:define>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -9,9 +9,6 @@
 
     <ui:fragment rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_CON')}">
         <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_CON') ">
-            <h1>#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.consultarBaja')}</h1>
-            <hr />
-
             <h:form id="frmConsultaBaja">
                 <p:messages id="msgsConsultaBaja" autoUpdate="true" closable="true" />
 

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -1,47 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html>
-<ui:composition template="/templates/layout.xhtml"
-                xmlns="http://www.w3.org/1999/xhtml"
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:h="http://java.sun.com/jsf/html"
                 xmlns:ui="http://java.sun.com/jsf/facelets"
                 xmlns:f="http://java.sun.com/jsf/core"
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:sec="http://www.springframework.org/security/tags">
 
-    <ui:define name="breadcrumb">
-        <li>#{sistema.obtenerTexto('gw.gestionescolar.label.gestionEscolar')}</li>
-        <li>#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.titulo')}</li>
-        <li class="active">#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.consultarBaja')}</li>
-    </ui:define>
+    <ui:fragment rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_CON')}">
+        <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_CON') ">
+            <h1>#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.consultarBaja')}</h1>
+            <hr />
 
-    <ui:define name="content">
-        <ui:fragment rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_CON')}">
-            <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_CON') ">
-                <h1>#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.consultarBaja')}</h1>
-                <hr />
+            <h:form id="frmConsultaBaja">
+                <p:messages id="msgsConsultaBaja" autoUpdate="true" closable="true" />
 
-                <h:form id="frmConsultaBaja">
-                    <p:messages id="msgsConsultaBaja" autoUpdate="true" closable="true" />
-
-                    <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.consultarBaja')}"
-                             styleClass="panel-primary">
-                        <div class="row">
-                            <div class="col-md-12">
-                                <h:outputText value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.mensaje.pendiente')}" />
-                            </div>
+                <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.consultarBaja')}"
+                         styleClass="panel-primary">
+                    <div class="row">
+                        <div class="col-md-12">
+                            <h:outputText value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.mensaje.pendiente')}" />
                         </div>
-                        <div class="row" style="margin-top: 15px;">
-                            <div class="col-md-12 text-right">
-                                <p:commandButton value="#{sistema.obtenerTexto('gw.ge.texto.regresar')}"
-                                                 action="#{altasBajasUsuariosBean.regresarAlModulo}"
-                                                 icon="fa fa-arrow-left"
-                                                 styleClass="btn btn-default"
-                                                 ajax="false" />
-                            </div>
+                    </div>
+                    <div class="row" style="margin-top: 15px;">
+                        <div class="col-md-12 text-right">
+                            <p:commandButton value="#{sistema.obtenerTexto('gw.ge.texto.regresar')}"
+                                             action="#{altasBajasUsuariosBean.regresarAlModulo}"
+                                             styleClass="btn btn-default"
+                                             ajax="false" />
                         </div>
-                    </p:panel>
-                </h:form>
-            </sec:authorize>
-        </ui:fragment>
-    </ui:define>
+                    </div>
+                </p:panel>
+            </h:form>
+        </sec:authorize>
+    </ui:fragment>
 </ui:composition>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml
@@ -9,9 +9,6 @@
 
     <ui:fragment rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_ALT')}">
         <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_ALT') ">
-            <h1>#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaAlta')}</h1>
-            <hr />
-
             <h:form id="frmNuevaAlta">
                 <p:messages id="msgsNuevaAlta" autoUpdate="true" closable="true" />
 

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml
@@ -1,47 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html>
-<ui:composition template="/templates/layout.xhtml"
-                xmlns="http://www.w3.org/1999/xhtml"
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:h="http://java.sun.com/jsf/html"
                 xmlns:ui="http://java.sun.com/jsf/facelets"
                 xmlns:f="http://java.sun.com/jsf/core"
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:sec="http://www.springframework.org/security/tags">
 
-    <ui:define name="breadcrumb">
-        <li>#{sistema.obtenerTexto('gw.gestionescolar.label.gestionEscolar')}</li>
-        <li>#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.titulo')}</li>
-        <li class="active">#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaAlta')}</li>
-    </ui:define>
+    <ui:fragment rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_ALT')}">
+        <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_ALT') ">
+            <h1>#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaAlta')}</h1>
+            <hr />
 
-    <ui:define name="content">
-        <ui:fragment rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_ALT')}">
-            <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_ALT') ">
-                <h1>#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaAlta')}</h1>
-                <hr />
+            <h:form id="frmNuevaAlta">
+                <p:messages id="msgsNuevaAlta" autoUpdate="true" closable="true" />
 
-                <h:form id="frmNuevaAlta">
-                    <p:messages id="msgsNuevaAlta" autoUpdate="true" closable="true" />
-
-                    <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaAlta')}"
-                             styleClass="panel-primary">
-                        <div class="row">
-                            <div class="col-md-12">
-                                <h:outputText value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.mensaje.pendiente')}" />
-                            </div>
+                <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaAlta')}"
+                         styleClass="panel-primary">
+                    <div class="row">
+                        <div class="col-md-12">
+                            <h:outputText value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.mensaje.pendiente')}" />
                         </div>
-                        <div class="row" style="margin-top: 15px;">
-                            <div class="col-md-12 text-right">
-                                <p:commandButton value="#{sistema.obtenerTexto('gw.ge.texto.regresar')}"
-                                                 action="#{altasBajasUsuariosBean.regresarAlModulo}"
-                                                 icon="fa fa-arrow-left"
-                                                 styleClass="btn btn-default"
-                                                 ajax="false" />
-                            </div>
+                    </div>
+                    <div class="row" style="margin-top: 15px;">
+                        <div class="col-md-12 text-right">
+                            <p:commandButton value="#{sistema.obtenerTexto('gw.ge.texto.regresar')}"
+                                             action="#{altasBajasUsuariosBean.regresarAlModulo}"
+                                             styleClass="btn btn-default"
+                                             ajax="false" />
                         </div>
-                    </p:panel>
-                </h:form>
-            </sec:authorize>
-        </ui:fragment>
-    </ui:define>
+                    </div>
+                </p:panel>
+            </h:form>
+        </sec:authorize>
+    </ui:fragment>
 </ui:composition>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -1,47 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html>
-<ui:composition template="/templates/layout.xhtml"
-                xmlns="http://www.w3.org/1999/xhtml"
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:h="http://java.sun.com/jsf/html"
                 xmlns:ui="http://java.sun.com/jsf/facelets"
                 xmlns:f="http://java.sun.com/jsf/core"
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:sec="http://www.springframework.org/security/tags">
 
-    <ui:define name="breadcrumb">
-        <li>#{sistema.obtenerTexto('gw.gestionescolar.label.gestionEscolar')}</li>
-        <li>#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.titulo')}</li>
-        <li class="active">#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaBaja')}</li>
-    </ui:define>
+    <ui:fragment rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_BAJ')}">
+        <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_BAJ') ">
+            <h1>#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaBaja')}</h1>
+            <hr />
 
-    <ui:define name="content">
-        <ui:fragment rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_BAJ')}">
-            <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_BAJ') ">
-                <h1>#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaBaja')}</h1>
-                <hr />
+            <h:form id="frmNuevaBaja">
+                <p:messages id="msgsNuevaBaja" autoUpdate="true" closable="true" />
 
-                <h:form id="frmNuevaBaja">
-                    <p:messages id="msgsNuevaBaja" autoUpdate="true" closable="true" />
-
-                    <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaBaja')}"
-                             styleClass="panel-primary">
-                        <div class="row">
-                            <div class="col-md-12">
-                                <h:outputText value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.mensaje.pendiente')}" />
-                            </div>
+                <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaBaja')}"
+                         styleClass="panel-primary">
+                    <div class="row">
+                        <div class="col-md-12">
+                            <h:outputText value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.mensaje.pendiente')}" />
                         </div>
-                        <div class="row" style="margin-top: 15px;">
-                            <div class="col-md-12 text-right">
-                                <p:commandButton value="#{sistema.obtenerTexto('gw.ge.texto.regresar')}"
-                                                 action="#{altasBajasUsuariosBean.regresarAlModulo}"
-                                                 icon="fa fa-arrow-left"
-                                                 styleClass="btn btn-default"
-                                                 ajax="false" />
-                            </div>
+                    </div>
+                    <div class="row" style="margin-top: 15px;">
+                        <div class="col-md-12 text-right">
+                            <p:commandButton value="#{sistema.obtenerTexto('gw.ge.texto.regresar')}"
+                                             action="#{altasBajasUsuariosBean.regresarAlModulo}"
+                                             styleClass="btn btn-default"
+                                             ajax="false" />
                         </div>
-                    </p:panel>
-                </h:form>
-            </sec:authorize>
-        </ui:fragment>
-    </ui:define>
+                    </div>
+                </p:panel>
+            </h:form>
+        </sec:authorize>
+    </ui:fragment>
 </ui:composition>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -9,9 +9,6 @@
 
     <ui:fragment rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_BAJ')}">
         <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_BAJ') ">
-            <h1>#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaBaja')}</h1>
-            <hr />
-
             <h:form id="frmNuevaBaja">
                 <p:messages id="msgsNuevaBaja" autoUpdate="true" closable="true" />
 

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/AltasBajasUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/AltasBajasUsuariosBean.java
@@ -7,7 +7,6 @@ import javax.faces.bean.ViewScoped;
 import org.apache.log4j.Logger;
 
 import mx.gob.sedesol.gestorweb.beans.acceso.BaseBean;
-import mx.gob.sedesol.gestorweb.commons.constantes.ConstantesGestorWeb;
 
 @ManagedBean
 @ViewScoped
@@ -17,28 +16,63 @@ public class AltasBajasUsuariosBean extends BaseBean {
 
     private static final Logger LOGGER = Logger.getLogger(AltasBajasUsuariosBean.class);
 
+    private String paginaActual;
+    private boolean mostrarOpcionesBajas;
+
     @PostConstruct
     public void init() {
         LOGGER.info("Inicializando módulo de altas y bajas de usuarios");
+        paginaActual = null;
+        mostrarOpcionesBajas = false;
     }
 
     public String irNuevaAlta() {
         LOGGER.info("Navegando a la vista de nueva alta de usuario");
-        return ConstantesGestorWeb.NAVEGA_NUEVA_ALTA_USUARIO;
+        this.paginaActual = "/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml";
+        this.mostrarOpcionesBajas = false;
+        return null;
     }
 
     public String irNuevaBaja() {
         LOGGER.info("Navegando a la vista de nueva baja de usuario");
-        return ConstantesGestorWeb.NAVEGA_NUEVA_BAJA_USUARIO;
+        this.paginaActual = "/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml";
+        this.mostrarOpcionesBajas = false;
+        return null;
     }
 
     public String irConsultarBaja() {
         LOGGER.info("Navegando a la vista de consulta de bajas de usuario");
-        return ConstantesGestorWeb.NAVEGA_CONSULTA_BAJA_USUARIO;
+        this.paginaActual = "/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml";
+        this.mostrarOpcionesBajas = false;
+        return null;
     }
 
     public String regresarAlModulo() {
         LOGGER.info("Regresando al módulo de altas y bajas de usuarios");
-        return ConstantesGestorWeb.NAVEGA_ALTAS_BAJAS_USUARIOS;
+        this.paginaActual = null;
+        this.mostrarOpcionesBajas = false;
+        return null;
+    }
+
+    public void mostrarOpcionesBajas() {
+        LOGGER.info("Mostrando opciones disponibles para las bajas de usuario");
+        this.paginaActual = null;
+        this.mostrarOpcionesBajas = true;
+    }
+
+    public String getPaginaActual() {
+        return paginaActual;
+    }
+
+    public void setPaginaActual(String paginaActual) {
+        this.paginaActual = paginaActual;
+    }
+
+    public boolean isMostrarOpcionesBajas() {
+        return mostrarOpcionesBajas;
+    }
+
+    public void setMostrarOpcionesBajas(boolean mostrarOpcionesBajas) {
+        this.mostrarOpcionesBajas = mostrarOpcionesBajas;
     }
 }

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/AltasBajasUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/AltasBajasUsuariosBean.java
@@ -17,34 +17,47 @@ public class AltasBajasUsuariosBean extends BaseBean {
     private static final Logger LOGGER = Logger.getLogger(AltasBajasUsuariosBean.class);
 
     private String paginaActual;
+    private boolean mostrarOpcionesBajas;
 
     @PostConstruct
     public void init() {
         LOGGER.info("Inicializando módulo de altas y bajas de usuarios");
         paginaActual = null;
+        mostrarOpcionesBajas = false;
     }
 
     public String irNuevaAlta() {
         LOGGER.info("Navegando a la vista de nueva alta de usuario");
         this.paginaActual = "/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml";
+        this.mostrarOpcionesBajas = false;
         return null;
     }
 
     public String irNuevaBaja() {
         LOGGER.info("Navegando a la vista de nueva baja de usuario");
         this.paginaActual = "/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml";
+        this.mostrarOpcionesBajas = true;
         return null;
     }
 
     public String irConsultarBaja() {
         LOGGER.info("Navegando a la vista de consulta de bajas de usuario");
         this.paginaActual = "/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml";
+        this.mostrarOpcionesBajas = true;
+        return null;
+    }
+
+    public String mostrarOpcionesBajas() {
+        LOGGER.info("Mostrando opciones de bajas de usuarios");
+        this.mostrarOpcionesBajas = true;
+        this.paginaActual = null;
         return null;
     }
 
     public String regresarAlModulo() {
         LOGGER.info("Regresando al módulo de altas y bajas de usuarios");
         this.paginaActual = null;
+        this.mostrarOpcionesBajas = false;
         return null;
     }
 
@@ -54,5 +67,13 @@ public class AltasBajasUsuariosBean extends BaseBean {
 
     public void setPaginaActual(String paginaActual) {
         this.paginaActual = paginaActual;
+    }
+
+    public boolean isMostrarOpcionesBajas() {
+        return mostrarOpcionesBajas;
+    }
+
+    public void setMostrarOpcionesBajas(boolean mostrarOpcionesBajas) {
+        this.mostrarOpcionesBajas = mostrarOpcionesBajas;
     }
 }

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/AltasBajasUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/AltasBajasUsuariosBean.java
@@ -17,47 +17,35 @@ public class AltasBajasUsuariosBean extends BaseBean {
     private static final Logger LOGGER = Logger.getLogger(AltasBajasUsuariosBean.class);
 
     private String paginaActual;
-    private boolean mostrarOpcionesBajas;
 
     @PostConstruct
     public void init() {
         LOGGER.info("Inicializando módulo de altas y bajas de usuarios");
         paginaActual = null;
-        mostrarOpcionesBajas = false;
     }
 
     public String irNuevaAlta() {
         LOGGER.info("Navegando a la vista de nueva alta de usuario");
         this.paginaActual = "/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml";
-        this.mostrarOpcionesBajas = false;
         return null;
     }
 
     public String irNuevaBaja() {
         LOGGER.info("Navegando a la vista de nueva baja de usuario");
         this.paginaActual = "/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml";
-        this.mostrarOpcionesBajas = false;
         return null;
     }
 
     public String irConsultarBaja() {
         LOGGER.info("Navegando a la vista de consulta de bajas de usuario");
         this.paginaActual = "/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml";
-        this.mostrarOpcionesBajas = false;
         return null;
     }
 
     public String regresarAlModulo() {
         LOGGER.info("Regresando al módulo de altas y bajas de usuarios");
         this.paginaActual = null;
-        this.mostrarOpcionesBajas = false;
         return null;
-    }
-
-    public void mostrarOpcionesBajas() {
-        LOGGER.info("Mostrando opciones disponibles para las bajas de usuario");
-        this.paginaActual = null;
-        this.mostrarOpcionesBajas = true;
     }
 
     public String getPaginaActual() {
@@ -66,13 +54,5 @@ public class AltasBajasUsuariosBean extends BaseBean {
 
     public void setPaginaActual(String paginaActual) {
         this.paginaActual = paginaActual;
-    }
-
-    public boolean isMostrarOpcionesBajas() {
-        return mostrarOpcionesBajas;
-    }
-
-    public void setMostrarOpcionesBajas(boolean mostrarOpcionesBajas) {
-        this.mostrarOpcionesBajas = mostrarOpcionesBajas;
     }
 }


### PR DESCRIPTION
## Summary
- reorganize the vista principal de Altas y Bajas para que los botones de Altas y Bajas permitan acceder a las funcionalidades correspondientes desde la misma pantalla
- agregar control en el bean para mostrar u ocultar las opciones de bajas y limpiar el estado al navegar a cada submódulo

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69150f6ed840832fb45f24b319e853f4)