### PR TITLE
Add altas y bajas de usuarios module

### DIFF
--- a/codigoFuente/bd/18_altas_bajas_usuarios.sql
+++ b/codigoFuente/bd/18_altas_bajas_usuarios.sql
@@ -1,0 +1,109 @@
+-- Funcionalidades para el módulo de altas y bajas de usuarios
+INSERT INTO `tbl_funcionalidades` (`clave`, `id_funcionalidad_padre`, `descripcion`, `activo`, `usuario_modifico`)
+SELECT 'ALT_BAJ_USR', padre.id_funcionalidad, 'Altas y bajas de usuarios', 1, 1
+FROM `tbl_funcionalidades` padre
+WHERE padre.clave = 'GES_ESC'
+        AND NOT EXISTS (SELECT 1 FROM `tbl_funcionalidades` WHERE clave = 'ALT_BAJ_USR');
+
+INSERT INTO `tbl_funcionalidades` (`clave`, `id_funcionalidad_padre`, `descripcion`, `activo`, `usuario_modifico`)
+SELECT 'ALT_BAJ_USR_ALT', padre.id_funcionalidad, 'Nueva alta de usuarios', 1, 1
+FROM `tbl_funcionalidades` padre
+WHERE padre.clave = 'ALT_BAJ_USR'
+        AND NOT EXISTS (SELECT 1 FROM `tbl_funcionalidades` WHERE clave = 'ALT_BAJ_USR_ALT');
+
+INSERT INTO `tbl_funcionalidades` (`clave`, `id_funcionalidad_padre`, `descripcion`, `activo`, `usuario_modifico`)
+SELECT 'ALT_BAJ_USR_BAJ', padre.id_funcionalidad, 'Nueva baja de usuarios', 1, 1
+FROM `tbl_funcionalidades` padre
+WHERE padre.clave = 'ALT_BAJ_USR'
+        AND NOT EXISTS (SELECT 1 FROM `tbl_funcionalidades` WHERE clave = 'ALT_BAJ_USR_BAJ');
+
+INSERT INTO `tbl_funcionalidades` (`clave`, `id_funcionalidad_padre`, `descripcion`, `activo`, `usuario_modifico`)
+SELECT 'ALT_BAJ_USR_CON', padre.id_funcionalidad, 'Consulta de bajas de usuarios', 1, 1
+FROM `tbl_funcionalidades` padre
+WHERE padre.clave = 'ALT_BAJ_USR'
+        AND NOT EXISTS (SELECT 1 FROM `tbl_funcionalidades` WHERE clave = 'ALT_BAJ_USR_CON');
+
+-- Textos de sistema para internacionalización
+INSERT INTO `tbl_textos_sistema` (`clave`, `valor`, `id_funcionalidad`, `usuario_modifico`)
+SELECT 'gw.altasbajasusuarios.titulo', 'Altas y bajas de usuarios', func.id_funcionalidad, 1
+FROM `tbl_funcionalidades` func
+WHERE func.clave = 'ALT_BAJ_USR'
+        ON DUPLICATE KEY UPDATE `valor` = VALUES(`valor`);
+
+INSERT INTO `tbl_textos_sistema` (`clave`, `valor`, `id_funcionalidad`, `usuario_modifico`)
+SELECT 'gw.altasbajasusuarios.boton.altas', 'Altas', func.id_funcionalidad, 1
+FROM `tbl_funcionalidades` func
+WHERE func.clave = 'ALT_BAJ_USR'
+        ON DUPLICATE KEY UPDATE `valor` = VALUES(`valor`);
+
+INSERT INTO `tbl_textos_sistema` (`clave`, `valor`, `id_funcionalidad`, `usuario_modifico`)
+SELECT 'gw.altasbajasusuarios.boton.bajas', 'Bajas', func.id_funcionalidad, 1
+FROM `tbl_funcionalidades` func
+WHERE func.clave = 'ALT_BAJ_USR'
+        ON DUPLICATE KEY UPDATE `valor` = VALUES(`valor`);
+
+INSERT INTO `tbl_textos_sistema` (`clave`, `valor`, `id_funcionalidad`, `usuario_modifico`)
+SELECT 'gw.altasbajasusuarios.boton.nuevaBaja', 'Nueva baja', func.id_funcionalidad, 1
+FROM `tbl_funcionalidades` func
+WHERE func.clave = 'ALT_BAJ_USR'
+        ON DUPLICATE KEY UPDATE `valor` = VALUES(`valor`);
+
+INSERT INTO `tbl_textos_sistema` (`clave`, `valor`, `id_funcionalidad`, `usuario_modifico`)
+SELECT 'gw.altasbajasusuarios.boton.consultarBaja', 'Consultar baja', func.id_funcionalidad, 1
+FROM `tbl_funcionalidades` func
+WHERE func.clave = 'ALT_BAJ_USR'
+        ON DUPLICATE KEY UPDATE `valor` = VALUES(`valor`);
+
+INSERT INTO `tbl_textos_sistema` (`clave`, `valor`, `id_funcionalidad`, `usuario_modifico`)
+SELECT 'gw.altasbajasusuarios.boton.regresar', 'Regresar', func.id_funcionalidad, 1
+FROM `tbl_funcionalidades` func
+WHERE func.clave = 'ALT_BAJ_USR'
+        ON DUPLICATE KEY UPDATE `valor` = VALUES(`valor`);
+
+INSERT INTO `tbl_textos_sistema` (`clave`, `valor`, `id_funcionalidad`, `usuario_modifico`)
+SELECT 'gw.altasbajasusuarios.panel.instrucciones.titulo', 'Seleccione una acción', func.id_funcionalidad, 1
+FROM `tbl_funcionalidades` func
+WHERE func.clave = 'ALT_BAJ_USR'
+        ON DUPLICATE KEY UPDATE `valor` = VALUES(`valor`);
+
+INSERT INTO `tbl_textos_sistema` (`clave`, `valor`, `id_funcionalidad`, `usuario_modifico`)
+SELECT 'gw.altasbajasusuarios.panel.instrucciones.descripcion', 'Utilice los botones disponibles para iniciar una nueva alta o administrar bajas.', func.id_funcionalidad, 1
+FROM `tbl_funcionalidades` func
+WHERE func.clave = 'ALT_BAJ_USR'
+        ON DUPLICATE KEY UPDATE `valor` = VALUES(`valor`);
+
+INSERT INTO `tbl_textos_sistema` (`clave`, `valor`, `id_funcionalidad`, `usuario_modifico`)
+SELECT 'gw.altasbajasusuarios.panel.nuevaAlta.titulo', 'Registrar nueva alta', func.id_funcionalidad, 1
+FROM `tbl_funcionalidades` func
+WHERE func.clave = 'ALT_BAJ_USR'
+        ON DUPLICATE KEY UPDATE `valor` = VALUES(`valor`);
+
+INSERT INTO `tbl_textos_sistema` (`clave`, `valor`, `id_funcionalidad`, `usuario_modifico`)
+SELECT 'gw.altasbajasusuarios.panel.nuevaAlta.descripcion', 'En esta sección se registrarán las altas de usuarios seleccionados.', func.id_funcionalidad, 1
+FROM `tbl_funcionalidades` func
+WHERE func.clave = 'ALT_BAJ_USR'
+        ON DUPLICATE KEY UPDATE `valor` = VALUES(`valor`);
+
+INSERT INTO `tbl_textos_sistema` (`clave`, `valor`, `id_funcionalidad`, `usuario_modifico`)
+SELECT 'gw.altasbajasusuarios.panel.nuevaBaja.titulo', 'Registrar nueva baja', func.id_funcionalidad, 1
+FROM `tbl_funcionalidades` func
+WHERE func.clave = 'ALT_BAJ_USR'
+        ON DUPLICATE KEY UPDATE `valor` = VALUES(`valor`);
+
+INSERT INTO `tbl_textos_sistema` (`clave`, `valor`, `id_funcionalidad`, `usuario_modifico`)
+SELECT 'gw.altasbajasusuarios.panel.nuevaBaja.descripcion', 'Esta vista permitirá capturar la información de una baja.', func.id_funcionalidad, 1
+FROM `tbl_funcionalidades` func
+WHERE func.clave = 'ALT_BAJ_USR'
+        ON DUPLICATE KEY UPDATE `valor` = VALUES(`valor`);
+
+INSERT INTO `tbl_textos_sistema` (`clave`, `valor`, `id_funcionalidad`, `usuario_modifico`)
+SELECT 'gw.altasbajasusuarios.panel.consultarBaja.titulo', 'Consultar baja', func.id_funcionalidad, 1
+FROM `tbl_funcionalidades` func
+WHERE func.clave = 'ALT_BAJ_USR'
+        ON DUPLICATE KEY UPDATE `valor` = VALUES(`valor`);
+
+INSERT INTO `tbl_textos_sistema` (`clave`, `valor`, `id_funcionalidad`, `usuario_modifico`)
+SELECT 'gw.altasbajasusuarios.panel.consultarBaja.descripcion', 'Utilice esta pantalla para revisar el historial de bajas registradas.', func.id_funcionalidad, 1
+FROM `tbl_funcionalidades` func
+WHERE func.clave = 'ALT_BAJ_USR'
+        ON DUPLICATE KEY UPDATE `valor` = VALUES(`valor`);

--- a/codigoFuente/gestorWeb/WebContent/WEB-INF/faces-config.xml
+++ b/codigoFuente/gestorWeb/WebContent/WEB-INF/faces-config.xml
@@ -569,12 +569,18 @@
 		</navigation-case>
 
 		<!-- ITTIVA 666 MIS_DISPERSIONES -->
-		<navigation-case>
-			<from-outcome>MIS_DISPERSIONES</from-outcome>
-			<to-view-id>/views/private/gestionAprendizaje/alumnoView/busquedaDispersiones</to-view-id>
-			<redirect />
-		</navigation-case>
-		
+                <navigation-case>
+                        <from-outcome>MIS_DISPERSIONES</from-outcome>
+                        <to-view-id>/views/private/gestionAprendizaje/alumnoView/busquedaDispersiones</to-view-id>
+                        <redirect />
+                </navigation-case>
+
+                <navigation-case>
+                        <from-outcome>ALTAS_BAJAS_USUARIOS</from-outcome>
+                        <to-view-id>/views/private/gestionEscolar/altasBajasUsuarios/altasBajasUsuarios.xhtml</to-view-id>
+                        <redirect />
+                </navigation-case>
+
 
 		<!-- ITTIVA 666 MIS INSCRIPCION -->
 		<navigation-case>

--- a/codigoFuente/gestorWeb/WebContent/templates/private/sidebar.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/templates/private/sidebar.xhtml
@@ -441,7 +441,7 @@
                                                                                         <ui:fragment
                                                                                                 rendered="#{menuGestorBean.rolTienePermiso('MIS_CONVOCATORIAS')}">
                                                                                                 <sec:authorize access="hasPermission(null, 'MIS_CONVOCATORIAS') ">
-                                                                                                        <li><h:commandLink
+                                                                                                <li><h:commandLink
                                                                                                                         action="#{menuGestorBean.navegaMisConvocatorias}" title="Convocatorias">
                                                                                                                         <i class="fa fa-solid fa-id-card"></i>
                                                                                                                         <span class="m-label">Convocatorias</span>
@@ -450,8 +450,8 @@
                                                                                                 </sec:authorize>
                                                                                         </ui:fragment>
 
-																						<ui:fragment
-																								rendered="#{menuGestorBean.rolTienePermiso('MIS_INSCRIPCIONES')}">
+                                                                                                                               <ui:fragment
+                                                                                                                               rendered="#{menuGestorBean.rolTienePermiso('MIS_INSCRIPCIONES')}">
 																							<sec:authorize access="hasPermission(null, 'MIS_INSCRIPCIONES') ">
 																								<li><h:commandLink
 																										action="#{menuGestorBean.navegaMisInscripciones}" title="Inscripciones">
@@ -465,19 +465,30 @@
 											<ui:fragment
 													rendered="#{menuGestorBean.rolTienePermiso('MIS_DISPERSIONES')}">
 												<sec:authorize access="hasPermission(null, 'MIS_DISPERSIONES') ">
-													<li><h:commandLink
-															action="#{menuGestorBean.navegaMisDispersiones}" title="Dispersiones">
-														<i class="fa fa-solid fa-id-card"></i>
-														<span class="m-label">Dispersiones</span>
+                                                                                                <li><h:commandLink
+                                                                                                                        action="#{menuGestorBean.navegaMisDispersiones}" title="Dispersiones">
+                                                                                                                <i class="fa fa-solid fa-id-card"></i>
+                                                                                                                <span class="m-label">Dispersiones</span>
 
-													</h:commandLink></li>
-												</sec:authorize>
-											</ui:fragment>
+                                                                                                        </h:commandLink></li>
+                                                                                                </sec:authorize>
+                                                                                        </ui:fragment>
+                                                                                        <ui:fragment
+                                                                                                        rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR')}">
+                                                                                                <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR') ">
+                                                                                                        <li><h:commandLink
+                                                                                                                        action="#{menuGestorBean.navegaAltasBajasUsuarios}"
+                                                                                                                        title="#{sistema.obtenerTexto('gw.altasbajasusuarios.titulo')}">
+                                                                                                                        <i class="fa fa-user-plus"></i>
+                                                                                                                        <span class="m-label">#{sistema.obtenerTexto('gw.altasbajasusuarios.titulo')}</span>
+                                                                                                                </h:commandLink></li>
+                                                                                                </sec:authorize>
+                                                                                        </ui:fragment>
                                                                                         <li><h:commandLink
                                                                                                         action="#{menuGestorBean.navegaExpedienteAlumoBuscar}"
                                                                                                         title="#{sistema.obtenerTexto('gw.gestionaprendizaje.expediente.titulo')}">
                                                                                                         <i class="fa fa-solid fa-id-card"></i>
-													<span class="m-label">#{sistema.obtenerTexto('gw.gestionaprendizaje.expediente.titulo')}</span>
+                                                                                                        <span class="m-label">#{sistema.obtenerTexto('gw.gestionaprendizaje.expediente.titulo')}</span>
 												</h:commandLink></li>
 											<li><h:commandLink
 													action="#{menuGestorBean.navegaExpedienteGrupo}"

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/altasBajasUsuarios.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/altasBajasUsuarios.xhtml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ui:composition template="/templates/layout.xhtml"
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:h="http://java.sun.com/jsf/html"
+        xmlns:ui="http://java.sun.com/jsf/facelets"
+        xmlns:f="http://java.sun.com/jsf/core"
+        xmlns:p="http://primefaces.org/ui"
+        xmlns:sec="http://www.springframework.org/security/tags">
+
+        <ui:define name="breadcrumb">
+                <li>#{sistema.obtenerTexto('gw.gestionescolar.label.gestionEscolar')}</li>
+                <li class="active">#{sistema.obtenerTexto('gw.altasbajasusuarios.titulo')}</li>
+        </ui:define>
+
+        <ui:define name="content">
+                <h:form>
+                        <h1>
+                                <p:outputLabel styleClass="h1" value="#{sistema.obtenerTexto('gw.altasbajasusuarios.titulo')}" />
+                        </h1>
+
+                        <p:ajaxStatus onstart="PF('dialogLayout').show()"
+                                onsuccess="PF('dialogLayout').hide()" />
+
+                        <br />
+
+                        <div class="form-group">
+                                <div class="row">
+                                        <ui:fragment rendered="#{!altasBajasUsuariosBean.mostrarOpcionesBaja}">
+                                                <sec:authorize access="hasPermission(null,'ALT_BAJ_USR_ALT')">
+                                                        <p:commandButton value="#{sistema.obtenerTexto('gw.altasbajasusuarios.boton.altas')}"
+                                                                action="#{altasBajasUsuariosBean.navegaNuevaAlta}"
+                                                                ajax="false" immediate="true" process="@this"
+                                                                styleClass="btn btn-primary" />
+                                                </sec:authorize>
+                                                <sec:authorize access="hasPermission(null,'ALT_BAJ_USR_BAJ') or hasPermission(null,'ALT_BAJ_USR_CON')">
+                                                        <p:commandButton value="#{sistema.obtenerTexto('gw.altasbajasusuarios.boton.bajas')}"
+                                                                action="#{altasBajasUsuariosBean.prepararBajas}"
+                                                                ajax="false" immediate="true" process="@this"
+                                                                styleClass="btn btn-primary" />
+                                                </sec:authorize>
+                                        </ui:fragment>
+                                        <ui:fragment rendered="#{altasBajasUsuariosBean.mostrarOpcionesBaja}">
+                                                <sec:authorize access="hasPermission(null,'ALT_BAJ_USR_BAJ')">
+                                                        <p:commandButton value="#{sistema.obtenerTexto('gw.altasbajasusuarios.boton.nuevaBaja')}"
+                                                                action="#{altasBajasUsuariosBean.navegaNuevaBaja}"
+                                                                ajax="false" immediate="true" process="@this"
+                                                                styleClass="btn btn-primary" />
+                                                </sec:authorize>
+                                                <sec:authorize access="hasPermission(null,'ALT_BAJ_USR_CON')">
+                                                        <p:commandButton value="#{sistema.obtenerTexto('gw.altasbajasusuarios.boton.consultarBaja')}"
+                                                                action="#{altasBajasUsuariosBean.navegaConsultaBaja}"
+                                                                ajax="false" immediate="true" process="@this"
+                                                                styleClass="btn btn-primary" />
+                                                </sec:authorize>
+                                                <p:commandButton value="#{sistema.obtenerTexto('gw.altasbajasusuarios.boton.regresar')}"
+                                                        action="#{altasBajasUsuariosBean.regresarOpcionesPrincipales}"
+                                                        ajax="false" immediate="true" process="@this"
+                                                        styleClass="btn btn-primary" />
+                                        </ui:fragment>
+                                </div>
+                        </div>
+
+                        <ui:include src="#{altasBajasUsuariosBean.paginaActual}" />
+                </h:form>
+        </ui:define>
+</ui:composition>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBajaUsuario.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBajaUsuario.xhtml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE html>
+
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:ui="http://java.sun.com/jsf/facelets"
+        xmlns:p="http://primefaces.org/ui">
+
+        <p:panel styleClass="panel-primary" header="#{sistema.obtenerTexto('gw.altasbajasusuarios.panel.consultarBaja.titulo')}">
+                <div class="row">
+                        <div class="col-md-12">
+                                <p:outputLabel value="#{sistema.obtenerTexto('gw.altasbajasusuarios.panel.consultarBaja.descripcion')}" />
+                        </div>
+                </div>
+        </p:panel>
+</ui:composition>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/instruccionesAltasBajasUsuarios.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/instruccionesAltasBajasUsuarios.xhtml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE html>
+
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:ui="http://java.sun.com/jsf/facelets"
+        xmlns:p="http://primefaces.org/ui">
+
+        <p:panel styleClass="panel-primary" header="#{sistema.obtenerTexto('gw.altasbajasusuarios.panel.instrucciones.titulo')}">
+                <div class="row">
+                        <div class="col-md-12">
+                                <p:outputLabel value="#{sistema.obtenerTexto('gw.altasbajasusuarios.panel.instrucciones.descripcion')}" />
+                        </div>
+                </div>
+        </p:panel>
+</ui:composition>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaAltaUsuario.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaAltaUsuario.xhtml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE html>
+
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:ui="http://java.sun.com/jsf/facelets"
+        xmlns:p="http://primefaces.org/ui">
+
+        <p:panel styleClass="panel-primary" header="#{sistema.obtenerTexto('gw.altasbajasusuarios.panel.nuevaAlta.titulo')}">
+                <div class="row">
+                        <div class="col-md-12">
+                                <p:outputLabel value="#{sistema.obtenerTexto('gw.altasbajasusuarios.panel.nuevaAlta.descripcion')}" />
+                        </div>
+                </div>
+        </p:panel>
+</ui:composition>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBajaUsuario.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBajaUsuario.xhtml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE html>
+
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:ui="http://java.sun.com/jsf/facelets"
+        xmlns:p="http://primefaces.org/ui">
+
+        <p:panel styleClass="panel-primary" header="#{sistema.obtenerTexto('gw.altasbajasusuarios.panel.nuevaBaja.titulo')}">
+                <div class="row">
+                        <div class="col-md-12">
+                                <p:outputLabel value="#{sistema.obtenerTexto('gw.altasbajasusuarios.panel.nuevaBaja.descripcion')}" />
+                        </div>
+                </div>
+        </p:panel>
+</ui:composition>

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/acceso/MenuGestorBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/acceso/MenuGestorBean.java
@@ -416,23 +416,28 @@ public class MenuGestorBean extends BaseBean {
 		return ConstantesGestorWeb.NAVEGA_MIS_CURSOS;
 	}
 
-	//ITTIVA 666
-	public String navegaMisConvocatorias() {
-		logger.info("Navegando a mis convocatorias");
-		return ConstantesGestorWeb.NAVEGA_MIS_CONVOCATORIAS;
-	}
-	
-	//ITTIVA 666
-		public String navegaMisDispersiones() {
-			logger.info("Navegando a mis dispersiones");
-			return ConstantesGestorWeb.NAVEGA_MIS_DISPERSIONES;
-		}
-	
-	//ITTIVA 666
-		public String navegaMisInscripciones() {
-			logger.info("Navegando a mis inscripciones");
-			return ConstantesGestorWeb.NAVEGA_MIS_INSCRIPCIONES;
-		}
+        //ITTIVA 666
+        public String navegaMisConvocatorias() {
+                logger.info("Navegando a mis convocatorias");
+                return ConstantesGestorWeb.NAVEGA_MIS_CONVOCATORIAS;
+        }
+
+        //ITTIVA 666
+                public String navegaMisDispersiones() {
+                        logger.info("Navegando a mis dispersiones");
+                        return ConstantesGestorWeb.NAVEGA_MIS_DISPERSIONES;
+                }
+
+        //ITTIVA 666
+                public String navegaMisInscripciones() {
+                        logger.info("Navegando a mis inscripciones");
+                        return ConstantesGestorWeb.NAVEGA_MIS_INSCRIPCIONES;
+                }
+
+        public String navegaAltasBajasUsuarios() {
+                logger.info("Navegando a altas y bajas de usuarios");
+                return ConstantesGestorWeb.NAVEGA_ALTAS_BAJAS_USUARIOS;
+        }
 		
 	//ITTIVA 666
 	public String navegaInscripcion() {

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/AltasBajasUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/AltasBajasUsuariosBean.java
@@ -1,0 +1,70 @@
+package mx.gob.sedesol.gestorweb.beans.gestionescolar;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ViewScoped;
+
+import org.apache.log4j.Logger;
+
+import mx.gob.sedesol.gestorweb.beans.acceso.BaseBean;
+
+@ManagedBean
+@ViewScoped
+public class AltasBajasUsuariosBean extends BaseBean {
+
+        private static final long serialVersionUID = 1L;
+
+        private static final Logger LOGGER = Logger.getLogger(AltasBajasUsuariosBean.class);
+        private static final String RUTA_BASE = "/views/private/gestionEscolar/altasBajasUsuarios/";
+
+        private String paginaActual;
+        private boolean mostrarOpcionesBaja;
+
+        @PostConstruct
+        public void init() {
+                LOGGER.info("Inicializando módulo de altas y bajas de usuarios");
+                paginaActual = RUTA_BASE + "instruccionesAltasBajasUsuarios.xhtml";
+                mostrarOpcionesBaja = false;
+        }
+
+        public void navegaNuevaAlta() {
+                mostrarOpcionesBaja = false;
+                paginaActual = RUTA_BASE + "nuevaAltaUsuario.xhtml";
+        }
+
+        public void prepararBajas() {
+                mostrarOpcionesBaja = true;
+                paginaActual = RUTA_BASE + "instruccionesAltasBajasUsuarios.xhtml";
+        }
+
+        public void navegaNuevaBaja() {
+                mostrarOpcionesBaja = true;
+                paginaActual = RUTA_BASE + "nuevaBajaUsuario.xhtml";
+        }
+
+        public void navegaConsultaBaja() {
+                mostrarOpcionesBaja = true;
+                paginaActual = RUTA_BASE + "consultaBajaUsuario.xhtml";
+        }
+
+        public void regresarOpcionesPrincipales() {
+                mostrarOpcionesBaja = false;
+                paginaActual = RUTA_BASE + "instruccionesAltasBajasUsuarios.xhtml";
+        }
+
+        public String getPaginaActual() {
+                return paginaActual;
+        }
+
+        public void setPaginaActual(String paginaActual) {
+                this.paginaActual = paginaActual;
+        }
+
+        public boolean isMostrarOpcionesBaja() {
+                return mostrarOpcionesBaja;
+        }
+
+        public void setMostrarOpcionesBaja(boolean mostrarOpcionesBaja) {
+                this.mostrarOpcionesBaja = mostrarOpcionesBaja;
+        }
+}

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/commons/constantes/ConstantesGestorWeb.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/commons/constantes/ConstantesGestorWeb.java
@@ -410,7 +410,8 @@ public final class ConstantesGestorWeb {
 	//ITTIVA 666
 	public static final String NAVEGA_MIS_CONVOCATORIAS="MIS_CONVOCATORIAS";
 	public static final String NAVEGA_MIS_INSCRIPCIONES="MIS_INSCRIPCIONES";
-	public static final String NAVEGA_MIS_DISPERSIONES="MIS_DISPERSIONES";
+        public static final String NAVEGA_MIS_DISPERSIONES="MIS_DISPERSIONES";
+        public static final String NAVEGA_ALTAS_BAJAS_USUARIOS="ALTAS_BAJAS_USUARIOS";
 	
 	public static final String NAVEGA_INSCRIPCION="INSCRIPCION";
 	public static final String NAVEGA_NUEVA_CONVOCATORIAS="NAVEGA_NUEVA_CONVOCATORIAS";


### PR DESCRIPTION
## Summary
- add the Altas y bajas de usuarios managed bean, main page and placeholder subviews that share the dynamic include pattern from Convocatorias
- register the module in the left menu, navigation constants and faces-config navigation along with the database script for funcionalidades and textos

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aba821870832fbeba628705f48972)