### PR TITLE
Limit altas/bajas messages to module forms

### DIFF
--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/altasBajasUsuarios.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/altasBajasUsuarios.xhtml
@@ -20,7 +20,10 @@
                 <hr />
 
                 <h:form id="frmAltasBajas">
-                    <p:messages id="msgsAltasBajas" autoUpdate="true" closable="true" />
+                    <p:messages id="msgsAltasBajas"
+                                 autoUpdate="true"
+                                 closable="true"
+                                 for="@form" />
 
                     <div class="form-group">
                         <div class="row">

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -10,7 +10,10 @@
     <ui:fragment rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_CON')}">
         <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_CON') ">
             <h:form id="frmConsultaBaja">
-                <p:messages id="msgsConsultaBaja" autoUpdate="true" closable="true" />
+                <p:messages id="msgsConsultaBaja"
+                             autoUpdate="true"
+                             closable="true"
+                             for="@form" />
 
                 <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.consultarBaja')}"
                          styleClass="panel-primary">

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml
@@ -10,7 +10,10 @@
     <ui:fragment rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_ALT')}">
         <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_ALT') ">
             <h:form id="frmNuevaAlta">
-                <p:messages id="msgsNuevaAlta" autoUpdate="true" closable="true" />
+                <p:messages id="msgsNuevaAlta"
+                             autoUpdate="true"
+                             closable="true"
+                             for="@form" />
 
                 <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaAlta')}"
                          styleClass="panel-primary">

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -10,7 +10,10 @@
     <ui:fragment rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_BAJ')}">
         <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_BAJ') ">
             <h:form id="frmNuevaBaja">
-                <p:messages id="msgsNuevaBaja" autoUpdate="true" closable="true" />
+                <p:messages id="msgsNuevaBaja"
+                             autoUpdate="true"
+                             closable="true"
+                             for="@form" />
 
                 <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaBaja')}"
                          styleClass="panel-primary">


### PR DESCRIPTION
## Summary
- scope the Altas/Bajas landing page messages to the page form so unrelated global warnings are ignored
- do the same for the Alta, Baja and Consulta subviews so only their own validation feedback is displayed

## Testing
- not run (UI-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd21fae3c832f807ecc0d05652594)