### PR TITLE
Implementar formulario y servicio de nueva baja

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/BajaDetalleDTO.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/BajaDetalleDTO.java
@@ -1,0 +1,66 @@
+package mx.gob.sedesol.basegestor.commons.dto.gestionescolar;
+
+import java.io.Serializable;
+
+/**
+ * Representa la información de matrícula usada para aplicar una baja.
+ */
+public class BajaDetalleDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long idPersona;
+    private Integer idPlan;
+    private Integer idPrograma;
+    private Integer idEvento;
+    private Integer idGrupo;
+    private Integer procesoId;
+
+    public Long getIdPersona() {
+        return idPersona;
+    }
+
+    public void setIdPersona(Long idPersona) {
+        this.idPersona = idPersona;
+    }
+
+    public Integer getIdPlan() {
+        return idPlan;
+    }
+
+    public void setIdPlan(Integer idPlan) {
+        this.idPlan = idPlan;
+    }
+
+    public Integer getIdPrograma() {
+        return idPrograma;
+    }
+
+    public void setIdPrograma(Integer idPrograma) {
+        this.idPrograma = idPrograma;
+    }
+
+    public Integer getIdEvento() {
+        return idEvento;
+    }
+
+    public void setIdEvento(Integer idEvento) {
+        this.idEvento = idEvento;
+    }
+
+    public Integer getIdGrupo() {
+        return idGrupo;
+    }
+
+    public void setIdGrupo(Integer idGrupo) {
+        this.idGrupo = idGrupo;
+    }
+
+    public Integer getProcesoId() {
+        return procesoId;
+    }
+
+    public void setProcesoId(Integer procesoId) {
+        this.procesoId = procesoId;
+    }
+}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/CatalogoOpcionDTO.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/CatalogoOpcionDTO.java
@@ -1,0 +1,38 @@
+package mx.gob.sedesol.basegestor.commons.dto.gestionescolar;
+
+import java.io.Serializable;
+
+/**
+ * DTO sencillo para exponer opciones de catálogo en componentes genéricos.
+ */
+public class CatalogoOpcionDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private String descripcion;
+
+    public CatalogoOpcionDTO() {
+    }
+
+    public CatalogoOpcionDTO(Long id, String descripcion) {
+        this.id = id;
+        this.descripcion = descripcion;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/NuevaBajaDTO.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/NuevaBajaDTO.java
@@ -14,7 +14,7 @@ public class NuevaBajaDTO implements Serializable {
     private Long idTipoBaja;
     private Integer idPlan;
     private Integer semestre;
-    private String bloque;
+    private Integer bloque;
     private Integer idPrograma;
     private Integer idPeriodo;
     private Integer idEvento;
@@ -65,11 +65,11 @@ public class NuevaBajaDTO implements Serializable {
         this.semestre = semestre;
     }
 
-    public String getBloque() {
+    public Integer getBloque() {
         return bloque;
     }
 
-    public void setBloque(String bloque) {
+    public void setBloque(Integer bloque) {
         this.bloque = bloque;
     }
 

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/NuevaBajaDTO.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/NuevaBajaDTO.java
@@ -1,0 +1,147 @@
+package mx.gob.sedesol.basegestor.commons.dto.gestionescolar;
+
+import java.io.Serializable;
+
+/**
+ * DTO para transportar la información capturada en el formulario de nuevas bajas.
+ */
+public class NuevaBajaDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String matricula;
+    private Long idPersona;
+    private Long idTipoBaja;
+    private Integer idPlan;
+    private Integer semestre;
+    private String bloque;
+    private Integer idPrograma;
+    private Integer idPeriodo;
+    private Integer idEvento;
+    private String motivo;
+    private String quienAplica;
+    private String numeroSolicitud;
+    private Integer procesoId;
+    private Integer idGrupo;
+    private Integer idMotivo;
+
+    public String getMatricula() {
+        return matricula;
+    }
+
+    public void setMatricula(String matricula) {
+        this.matricula = matricula;
+    }
+
+    public Long getIdPersona() {
+        return idPersona;
+    }
+
+    public void setIdPersona(Long idPersona) {
+        this.idPersona = idPersona;
+    }
+
+    public Long getIdTipoBaja() {
+        return idTipoBaja;
+    }
+
+    public void setIdTipoBaja(Long idTipoBaja) {
+        this.idTipoBaja = idTipoBaja;
+    }
+
+    public Integer getIdPlan() {
+        return idPlan;
+    }
+
+    public void setIdPlan(Integer idPlan) {
+        this.idPlan = idPlan;
+    }
+
+    public Integer getSemestre() {
+        return semestre;
+    }
+
+    public void setSemestre(Integer semestre) {
+        this.semestre = semestre;
+    }
+
+    public String getBloque() {
+        return bloque;
+    }
+
+    public void setBloque(String bloque) {
+        this.bloque = bloque;
+    }
+
+    public Integer getIdPrograma() {
+        return idPrograma;
+    }
+
+    public void setIdPrograma(Integer idPrograma) {
+        this.idPrograma = idPrograma;
+    }
+
+    public Integer getIdPeriodo() {
+        return idPeriodo;
+    }
+
+    public void setIdPeriodo(Integer idPeriodo) {
+        this.idPeriodo = idPeriodo;
+    }
+
+    public Integer getIdEvento() {
+        return idEvento;
+    }
+
+    public void setIdEvento(Integer idEvento) {
+        this.idEvento = idEvento;
+    }
+
+    public String getMotivo() {
+        return motivo;
+    }
+
+    public void setMotivo(String motivo) {
+        this.motivo = motivo;
+    }
+
+    public String getQuienAplica() {
+        return quienAplica;
+    }
+
+    public void setQuienAplica(String quienAplica) {
+        this.quienAplica = quienAplica;
+    }
+
+    public String getNumeroSolicitud() {
+        return numeroSolicitud;
+    }
+
+    public void setNumeroSolicitud(String numeroSolicitud) {
+        this.numeroSolicitud = numeroSolicitud;
+    }
+
+    public Integer getProcesoId() {
+        return procesoId;
+    }
+
+    public void setProcesoId(Integer procesoId) {
+        this.procesoId = procesoId;
+    }
+
+    public Integer getIdGrupo() {
+        return idGrupo;
+    }
+
+    public void setIdGrupo(Integer idGrupo) {
+        this.idGrupo = idGrupo;
+    }
+
+    public Integer getIdMotivo() {
+        return idMotivo;
+    }
+
+    public void setIdMotivo(Integer idMotivo) {
+        this.idMotivo = idMotivo;
+    }
+}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/BajaUsuarioRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/BajaUsuarioRepository.java
@@ -48,72 +48,92 @@ public class BajaUsuarioRepository implements IBajaUsuarioRepository {
     }
 
     @Override
-    public List<CatalogoOpcionDTO> obtenerPlanesPorPersona(Long idPersona) {
-        String consulta = "SELECT DISTINCT ti.idplan, tp.nombre FROM tbl_inscripciones ti "
-                + " INNER JOIN tbl_planes tp ON tp.id_plan = ti.idplan"
-                + " WHERE ti.IdpersonaSIGIE = :idPersona ORDER BY tp.nombre";
-        Query query = entityManager.createNativeQuery(consulta);
-        query.setParameter("idPersona", idPersona);
-        return mapearCatalogos(query.getResultList());
+    public List<CatalogoOpcionDTO> obtenerPlanes() {
+        String consulta = "SELECT tmc.id, tmc.id_plan, tmc.nombre"
+                + " FROM tbl_malla_curricular tmc"
+                + " WHERE tmc.activo = 1 AND tmc.id_plan IS NOT NULL";
+        List<Object[]> resultado = entityManager.createNativeQuery(consulta).getResultList();
+        List<CatalogoOpcionDTO> planes = new ArrayList<>();
+        if (resultado != null) {
+            for (Object[] fila : resultado) {
+                CatalogoOpcionDTO dto = new CatalogoOpcionDTO();
+                dto.setId(fila[1] != null ? ((Number) fila[1]).longValue() : null);
+                dto.setDescripcion(fila[2] != null ? fila[2].toString() : "");
+                planes.add(dto);
+            }
+        }
+        return planes;
     }
 
     @Override
-    public List<CatalogoOpcionDTO> obtenerSemestres(Long idPersona, Integer idPlan) {
-        String consulta = "SELECT DISTINCT ti.semestre, CONCAT('Semestre ', ti.semestre)"
-                + " FROM tbl_inscripciones ti WHERE ti.IdpersonaSIGIE = :idPersona AND ti.idplan = :idPlan ORDER BY ti.semestre";
-        Query query = entityManager.createNativeQuery(consulta);
-        query.setParameter("idPersona", idPersona);
-        query.setParameter("idPlan", idPlan);
-        return mapearCatalogos(query.getResultList());
-    }
-
-    @Override
-    public List<CatalogoOpcionDTO> obtenerBloques(Long idPersona, Integer idPlan, Integer semestre) {
-        String consulta = "SELECT DISTINCT ti.bloque, ti.bloque FROM tbl_inscripciones ti"
-                + " WHERE ti.IdpersonaSIGIE = :idPersona AND ti.idplan = :idPlan"
-                + " AND (:semestre IS NULL OR ti.semestre = :semestre) ORDER BY ti.bloque";
-        Query query = entityManager.createNativeQuery(consulta);
-        query.setParameter("idPersona", idPersona);
-        query.setParameter("idPlan", idPlan);
-        query.setParameter("semestre", semestre);
-        return mapearCatalogos(query.getResultList());
-    }
-
-    @Override
-    public List<CatalogoOpcionDTO> obtenerProgramas(Long idPersona, Integer idPlan, Integer semestre, String bloque) {
-        String consulta = "SELECT DISTINCT ti.idprograma, ti.programa FROM tbl_inscripciones ti"
-                + " WHERE ti.IdpersonaSIGIE = :idPersona AND ti.idplan = :idPlan"
-                + " AND (:semestre IS NULL OR ti.semestre = :semestre)"
-                + " AND (:bloque IS NULL OR ti.bloque = :bloque) ORDER BY ti.programa";
-        Query query = entityManager.createNativeQuery(consulta);
-        query.setParameter("idPersona", idPersona);
-        query.setParameter("idPlan", idPlan);
-        query.setParameter("semestre", semestre);
-        query.setParameter("bloque", bloque);
-        return mapearCatalogos(query.getResultList());
-    }
-
-    @Override
-    public List<CatalogoOpcionDTO> obtenerPeriodos(Integer idPlan) {
-        String consulta = "SELECT cp.id_periodo, cp.nombre FROM tbl_planes tp"
-                + " INNER JOIN cat_periodos cp ON cp.id_periodo = tp.id_periodo"
-                + " WHERE tp.id_plan = :idPlan AND cp.activo = 1";
+    public List<CatalogoOpcionDTO> obtenerSemestres(Integer idPlan) {
+        String consulta = "SELECT tmc.id, tmc.nombre FROM tbl_malla_curricular tmc WHERE tmc.id_plan = :idPlan";
         Query query = entityManager.createNativeQuery(consulta);
         query.setParameter("idPlan", idPlan);
         return mapearCatalogos(query.getResultList());
     }
 
     @Override
-    public List<CatalogoOpcionDTO> obtenerEventos(Integer idPlan, Integer idPrograma) {
-        String consulta = "SELECT DISTINCT ti.idevento, COALESCE(te.nombre_ec, CONCAT('Evento ', ti.idevento))"
-                + " FROM tbl_inscripciones ti"
-                + " LEFT JOIN tbl_eventos te ON te.id_evento = ti.idevento"
-                + " WHERE ti.idplan = :idPlan AND (:idPrograma IS NULL OR ti.idprograma = :idPrograma)"
-                + " ORDER BY 2";
+    public List<CatalogoOpcionDTO> obtenerBloques(Integer idSemestre) {
+        String consulta = "SELECT tmc.id, tmc.nombre FROM tbl_malla_curricular tmc WHERE tmc.id_padre = :idSemestre";
         Query query = entityManager.createNativeQuery(consulta);
-        query.setParameter("idPlan", idPlan);
+        query.setParameter("idSemestre", idSemestre);
+        return mapearCatalogos(query.getResultList());
+    }
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerProgramas(Integer idEjeCapacitacion) {
+        String consulta = "SELECT * FROM tbl_ficha_descriptiva_programa tfdp WHERE tfdp.id_eje_capacitacion = :idEje";
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("idEje", idEjeCapacitacion);
+        List<Object[]> resultado = query.getResultList();
+        List<CatalogoOpcionDTO> programas = new ArrayList<>();
+        if (resultado != null) {
+            for (Object[] fila : resultado) {
+                CatalogoOpcionDTO dto = new CatalogoOpcionDTO();
+                dto.setId(fila[0] != null ? ((Number) fila[0]).longValue() : null);
+                dto.setDescripcion(fila[2] != null ? fila[2].toString() : "");
+                programas.add(dto);
+            }
+        }
+        return programas;
+    }
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerPeriodos() {
+        String consulta = "SELECT tpi.nombre_periodo FROM tbl_periodos_inscripcion tpi";
+        List<?> resultado = entityManager.createNativeQuery(consulta).getResultList();
+        List<CatalogoOpcionDTO> periodos = new ArrayList<>();
+        if (resultado != null) {
+            long consecutivo = 1L;
+            for (Object fila : resultado) {
+                CatalogoOpcionDTO dto = new CatalogoOpcionDTO();
+                dto.setId(consecutivo++);
+                dto.setDescripcion(fila != null ? fila.toString() : "");
+                periodos.add(dto);
+            }
+        }
+        return periodos;
+    }
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerEventos(String nombrePeriodo, Integer idPrograma) {
+        String consulta = "SELECT * FROM tbl_eventos te WHERE te.cve_evento_cap LIKE CONCAT('%', :nombrePeriodo, '%')"
+                + " AND te.id_programa = :idPrograma";
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("nombrePeriodo", nombrePeriodo);
         query.setParameter("idPrograma", idPrograma);
-        return mapearCatalogos(query.getResultList());
+        List<Object[]> resultado = query.getResultList();
+        List<CatalogoOpcionDTO> eventos = new ArrayList<>();
+        if (resultado != null) {
+            for (Object[] fila : resultado) {
+                CatalogoOpcionDTO dto = new CatalogoOpcionDTO();
+                dto.setId(fila[0] != null ? ((Number) fila[0]).longValue() : null);
+                dto.setDescripcion(fila[3] != null ? fila[3].toString() : (fila[4] != null ? fila[4].toString() : ""));
+                eventos.add(dto);
+            }
+        }
+        return eventos;
     }
 
     @Override

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/BajaUsuarioRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/BajaUsuarioRepository.java
@@ -1,0 +1,210 @@
+package mx.gob.sedesol.basegestor.model.repositories.gestionescolar;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaDetalleDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.CatalogoOpcionDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.NuevaBajaDTO;
+
+@Repository
+public class BajaUsuarioRepository implements IBajaUsuarioRepository {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerTiposBaja() {
+        String consulta = "SELECT ctb.id_tipo_baja, ctb.nombre FROM cat_tipo_bajas ctb WHERE ctb.activo = 1 ORDER BY ctb.nombre";
+        List<Object[]> resultado = entityManager.createNativeQuery(consulta).getResultList();
+        List<CatalogoOpcionDTO> lista = new ArrayList<>();
+        if (resultado != null) {
+            for (Object[] obj : resultado) {
+                lista.add(mapearCatalogo(obj));
+            }
+        }
+        return lista;
+    }
+
+    @Override
+    public Optional<Long> buscarPersonaPorMatricula(String matricula) {
+        String consulta = "SELECT tp.id_persona FROM tbl_persona tp WHERE tp.sso_idUsuario = :matricula AND tp.activo = 1";
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("matricula", matricula);
+        List<?> resultado = query.getResultList();
+        if (resultado.isEmpty()) {
+            return Optional.empty();
+        }
+        Number idPersona = (Number) resultado.get(0);
+        return Optional.ofNullable(idPersona != null ? idPersona.longValue() : null);
+    }
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerPlanesPorPersona(Long idPersona) {
+        String consulta = "SELECT DISTINCT ti.idplan, tp.nombre FROM tbl_inscripciones ti "
+                + " INNER JOIN tbl_planes tp ON tp.id_plan = ti.idplan"
+                + " WHERE ti.IdpersonaSIGIE = :idPersona ORDER BY tp.nombre";
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("idPersona", idPersona);
+        return mapearCatalogos(query.getResultList());
+    }
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerSemestres(Long idPersona, Integer idPlan) {
+        String consulta = "SELECT DISTINCT ti.semestre, CONCAT('Semestre ', ti.semestre)"
+                + " FROM tbl_inscripciones ti WHERE ti.IdpersonaSIGIE = :idPersona AND ti.idplan = :idPlan ORDER BY ti.semestre";
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("idPersona", idPersona);
+        query.setParameter("idPlan", idPlan);
+        return mapearCatalogos(query.getResultList());
+    }
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerBloques(Long idPersona, Integer idPlan, Integer semestre) {
+        String consulta = "SELECT DISTINCT ti.bloque, ti.bloque FROM tbl_inscripciones ti"
+                + " WHERE ti.IdpersonaSIGIE = :idPersona AND ti.idplan = :idPlan"
+                + " AND (:semestre IS NULL OR ti.semestre = :semestre) ORDER BY ti.bloque";
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("idPersona", idPersona);
+        query.setParameter("idPlan", idPlan);
+        query.setParameter("semestre", semestre);
+        return mapearCatalogos(query.getResultList());
+    }
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerProgramas(Long idPersona, Integer idPlan, Integer semestre, String bloque) {
+        String consulta = "SELECT DISTINCT ti.idprograma, ti.programa FROM tbl_inscripciones ti"
+                + " WHERE ti.IdpersonaSIGIE = :idPersona AND ti.idplan = :idPlan"
+                + " AND (:semestre IS NULL OR ti.semestre = :semestre)"
+                + " AND (:bloque IS NULL OR ti.bloque = :bloque) ORDER BY ti.programa";
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("idPersona", idPersona);
+        query.setParameter("idPlan", idPlan);
+        query.setParameter("semestre", semestre);
+        query.setParameter("bloque", bloque);
+        return mapearCatalogos(query.getResultList());
+    }
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerPeriodos(Integer idPlan) {
+        String consulta = "SELECT cp.id_periodo, cp.nombre FROM tbl_planes tp"
+                + " INNER JOIN cat_periodos cp ON cp.id_periodo = tp.id_periodo"
+                + " WHERE tp.id_plan = :idPlan AND cp.activo = 1";
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("idPlan", idPlan);
+        return mapearCatalogos(query.getResultList());
+    }
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerEventos(Integer idPlan, Integer idPrograma) {
+        String consulta = "SELECT DISTINCT ti.idevento, COALESCE(te.nombre_ec, CONCAT('Evento ', ti.idevento))"
+                + " FROM tbl_inscripciones ti"
+                + " LEFT JOIN tbl_eventos te ON te.id_evento = ti.idevento"
+                + " WHERE ti.idplan = :idPlan AND (:idPrograma IS NULL OR ti.idprograma = :idPrograma)"
+                + " ORDER BY 2";
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("idPlan", idPlan);
+        query.setParameter("idPrograma", idPrograma);
+        return mapearCatalogos(query.getResultList());
+    }
+
+    @Override
+    public Integer obtenerProcesoBajas() {
+        String consulta = "SELECT tpi.proceso_inscripcion_id FROM tbl_procesos_inscripcion tpi"
+                + " WHERE UPPER(tpi.nombre) LIKE '%BAJA%' AND tpi.activo = 1"
+                + " ORDER BY tpi.fecha_inicio DESC LIMIT 1";
+        List<?> resultado = entityManager.createNativeQuery(consulta).getResultList();
+        if (resultado.isEmpty()) {
+            return null;
+        }
+        return ((Number) resultado.get(0)).intValue();
+    }
+
+    @Override
+    public BajaDetalleDTO obtenerDetalleBaja(Long idPersona, Integer idPlan, Integer idPrograma, Integer idEvento) {
+        String consulta = "SELECT ti.IdpersonaSIGIE, ti.idplan, ti.idprograma, ti.idevento, tg.id"
+                + " FROM tbl_inscripciones ti"
+                + " LEFT JOIN tbl_grupos tg ON tg.id_evento = ti.idevento AND tg.clave = ti.groupbase"
+                + " WHERE ti.IdpersonaSIGIE = :idPersona AND ti.idplan = :idPlan"
+                + " AND (:idPrograma IS NULL OR ti.idprograma = :idPrograma)"
+                + " AND (:idEvento IS NULL OR ti.idevento = :idEvento)"
+                + " ORDER BY ti.fecha_registro DESC LIMIT 1";
+
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("idPersona", idPersona);
+        query.setParameter("idPlan", idPlan);
+        query.setParameter("idPrograma", idPrograma);
+        query.setParameter("idEvento", idEvento);
+
+        List<Object[]> resultado = query.getResultList();
+        if (resultado.isEmpty()) {
+            return null;
+        }
+
+        Object[] obj = resultado.get(0);
+        BajaDetalleDTO detalle = new BajaDetalleDTO();
+        detalle.setIdPersona(obj[0] != null ? ((Number) obj[0]).longValue() : null);
+        detalle.setIdPlan(obj[1] != null ? ((Number) obj[1]).intValue() : null);
+        detalle.setIdPrograma(obj[2] != null ? ((Number) obj[2]).intValue() : null);
+        detalle.setIdEvento(obj[3] != null ? ((Number) obj[3]).intValue() : null);
+        detalle.setIdGrupo(obj[4] != null ? ((Number) obj[4]).intValue() : null);
+        return detalle;
+    }
+
+    @Override
+    @Transactional
+    public Integer registrarMotivo(NuevaBajaDTO nuevaBaja) {
+        String consulta = "INSERT INTO rel_motivo_baja (tipo_baja_id, descripcion) VALUES (:tipoBajaId, :descripcion)";
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("tipoBajaId", nuevaBaja.getIdTipoBaja());
+        query.setParameter("descripcion", nuevaBaja.getMotivo());
+        query.executeUpdate();
+
+        Number id = (Number) entityManager.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult();
+        return id != null ? id.intValue() : null;
+    }
+
+    @Override
+    @Transactional
+    public void registrarBaja(NuevaBajaDTO nuevaBaja, Long usuarioSesion) {
+        String consulta = "INSERT INTO rel_persona_bajas (id_persona, motivo_baja_id, proceso_id, id_plan, id_programa, id_evento, id_grupo, id_user_enrolments_lms, usuario_modifico)"
+                + " VALUES (:idPersona, :motivoId, :procesoId, :idPlan, :idPrograma, :idEvento, :idGrupo, :idUserEnrolments, :usuarioModifico)";
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("idPersona", nuevaBaja.getIdPersona());
+        query.setParameter("motivoId", nuevaBaja.getIdMotivo());
+        query.setParameter("procesoId", nuevaBaja.getProcesoId());
+        query.setParameter("idPlan", nuevaBaja.getIdPlan());
+        query.setParameter("idPrograma", nuevaBaja.getIdPrograma());
+        query.setParameter("idEvento", nuevaBaja.getIdEvento());
+        query.setParameter("idGrupo", nuevaBaja.getIdGrupo() != null ? nuevaBaja.getIdGrupo() : 0);
+        // Integración Moodle pendiente: los identificadores externos se almacenan en cero.
+        query.setParameter("idUserEnrolments", 0);
+        query.setParameter("usuarioModifico", usuarioSesion != null ? usuarioSesion : 0L);
+        query.executeUpdate();
+    }
+
+    private List<CatalogoOpcionDTO> mapearCatalogos(List<?> resultados) {
+        List<CatalogoOpcionDTO> lista = new ArrayList<>();
+        if (resultados != null) {
+            for (Object obj : resultados) {
+                lista.add(mapearCatalogo((Object[]) obj));
+            }
+        }
+        return lista;
+    }
+
+    private CatalogoOpcionDTO mapearCatalogo(Object[] obj) {
+        CatalogoOpcionDTO dto = new CatalogoOpcionDTO();
+        dto.setId(obj[0] != null ? Long.valueOf(obj[0].toString()) : null);
+        dto.setDescripcion(obj[1] != null ? obj[1].toString() : "");
+        return dto;
+    }
+}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/IBajaUsuarioRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/IBajaUsuarioRepository.java
@@ -13,17 +13,17 @@ public interface IBajaUsuarioRepository {
 
     Optional<Long> buscarPersonaPorMatricula(String matricula);
 
-    List<CatalogoOpcionDTO> obtenerPlanesPorPersona(Long idPersona);
+    List<CatalogoOpcionDTO> obtenerPlanes();
 
-    List<CatalogoOpcionDTO> obtenerSemestres(Long idPersona, Integer idPlan);
+    List<CatalogoOpcionDTO> obtenerSemestres(Integer idPlan);
 
-    List<CatalogoOpcionDTO> obtenerBloques(Long idPersona, Integer idPlan, Integer semestre);
+    List<CatalogoOpcionDTO> obtenerBloques(Integer idSemestre);
 
-    List<CatalogoOpcionDTO> obtenerProgramas(Long idPersona, Integer idPlan, Integer semestre, String bloque);
+    List<CatalogoOpcionDTO> obtenerProgramas(Integer idEjeCapacitacion);
 
-    List<CatalogoOpcionDTO> obtenerPeriodos(Integer idPlan);
+    List<CatalogoOpcionDTO> obtenerPeriodos();
 
-    List<CatalogoOpcionDTO> obtenerEventos(Integer idPlan, Integer idPrograma);
+    List<CatalogoOpcionDTO> obtenerEventos(String nombrePeriodo, Integer idPrograma);
 
     Integer obtenerProcesoBajas();
 

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/IBajaUsuarioRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/IBajaUsuarioRepository.java
@@ -1,0 +1,35 @@
+package mx.gob.sedesol.basegestor.model.repositories.gestionescolar;
+
+import java.util.List;
+import java.util.Optional;
+
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaDetalleDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.CatalogoOpcionDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.NuevaBajaDTO;
+
+public interface IBajaUsuarioRepository {
+
+    List<CatalogoOpcionDTO> obtenerTiposBaja();
+
+    Optional<Long> buscarPersonaPorMatricula(String matricula);
+
+    List<CatalogoOpcionDTO> obtenerPlanesPorPersona(Long idPersona);
+
+    List<CatalogoOpcionDTO> obtenerSemestres(Long idPersona, Integer idPlan);
+
+    List<CatalogoOpcionDTO> obtenerBloques(Long idPersona, Integer idPlan, Integer semestre);
+
+    List<CatalogoOpcionDTO> obtenerProgramas(Long idPersona, Integer idPlan, Integer semestre, String bloque);
+
+    List<CatalogoOpcionDTO> obtenerPeriodos(Integer idPlan);
+
+    List<CatalogoOpcionDTO> obtenerEventos(Integer idPlan, Integer idPrograma);
+
+    Integer obtenerProcesoBajas();
+
+    BajaDetalleDTO obtenerDetalleBaja(Long idPersona, Integer idPlan, Integer idPrograma, Integer idEvento);
+
+    Integer registrarMotivo(NuevaBajaDTO nuevaBaja);
+
+    void registrarBaja(NuevaBajaDTO nuevaBaja, Long usuarioSesion);
+}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/BajaUsuarioService.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/BajaUsuarioService.java
@@ -14,17 +14,17 @@ public interface BajaUsuarioService {
 
     Optional<Long> buscarPersonaPorMatricula(String matricula);
 
-    List<CatalogoOpcionDTO> obtenerPlanesPorPersona(Long idPersona);
+    List<CatalogoOpcionDTO> obtenerPlanes();
 
-    List<CatalogoOpcionDTO> obtenerSemestres(Long idPersona, Integer idPlan);
+    List<CatalogoOpcionDTO> obtenerSemestres(Integer idPlan);
 
-    List<CatalogoOpcionDTO> obtenerBloques(Long idPersona, Integer idPlan, Integer semestre);
+    List<CatalogoOpcionDTO> obtenerBloques(Integer idSemestre);
 
-    List<CatalogoOpcionDTO> obtenerProgramas(Long idPersona, Integer idPlan, Integer semestre, String bloque);
+    List<CatalogoOpcionDTO> obtenerProgramas(Integer idEjeCapacitacion);
 
-    List<CatalogoOpcionDTO> obtenerPeriodos(Integer idPlan);
+    List<CatalogoOpcionDTO> obtenerPeriodos();
 
-    List<CatalogoOpcionDTO> obtenerEventos(Integer idPlan, Integer idPrograma);
+    List<CatalogoOpcionDTO> obtenerEventos(String nombrePeriodo, Integer idPrograma);
 
     BajaDetalleDTO obtenerDetalleBaja(Long idPersona, Integer idPlan, Integer idPrograma, Integer idEvento);
 

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/BajaUsuarioService.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/BajaUsuarioService.java
@@ -1,0 +1,32 @@
+package mx.gob.sedesol.basegestor.service.gestionescolar;
+
+import java.util.List;
+import java.util.Optional;
+
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaDetalleDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.CatalogoOpcionDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.NuevaBajaDTO;
+import mx.gob.sedesol.basegestor.service.ServiceException;
+
+public interface BajaUsuarioService {
+
+    List<CatalogoOpcionDTO> obtenerTiposBaja();
+
+    Optional<Long> buscarPersonaPorMatricula(String matricula);
+
+    List<CatalogoOpcionDTO> obtenerPlanesPorPersona(Long idPersona);
+
+    List<CatalogoOpcionDTO> obtenerSemestres(Long idPersona, Integer idPlan);
+
+    List<CatalogoOpcionDTO> obtenerBloques(Long idPersona, Integer idPlan, Integer semestre);
+
+    List<CatalogoOpcionDTO> obtenerProgramas(Long idPersona, Integer idPlan, Integer semestre, String bloque);
+
+    List<CatalogoOpcionDTO> obtenerPeriodos(Integer idPlan);
+
+    List<CatalogoOpcionDTO> obtenerEventos(Integer idPlan, Integer idPrograma);
+
+    BajaDetalleDTO obtenerDetalleBaja(Long idPersona, Integer idPlan, Integer idPrograma, Integer idEvento);
+
+    void aplicarBaja(NuevaBajaDTO nuevaBaja, Long usuarioSesion) throws ServiceException;
+}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/BajaUsuarioServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/BajaUsuarioServiceImpl.java
@@ -1,0 +1,121 @@
+package mx.gob.sedesol.basegestor.service.impl.gestionescolar;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaDetalleDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.CatalogoOpcionDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.NuevaBajaDTO;
+import mx.gob.sedesol.basegestor.model.repositories.gestionescolar.IBajaUsuarioRepository;
+import mx.gob.sedesol.basegestor.service.ServiceException;
+import mx.gob.sedesol.basegestor.service.gestionescolar.BajaUsuarioService;
+
+@Service("bajaUsuarioService")
+public class BajaUsuarioServiceImpl implements BajaUsuarioService {
+
+    @Autowired
+    private IBajaUsuarioRepository bajaUsuarioRepository;
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerTiposBaja() {
+        return bajaUsuarioRepository.obtenerTiposBaja();
+    }
+
+    @Override
+    public Optional<Long> buscarPersonaPorMatricula(String matricula) {
+        return bajaUsuarioRepository.buscarPersonaPorMatricula(matricula);
+    }
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerPlanesPorPersona(Long idPersona) {
+        return bajaUsuarioRepository.obtenerPlanesPorPersona(idPersona);
+    }
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerSemestres(Long idPersona, Integer idPlan) {
+        return bajaUsuarioRepository.obtenerSemestres(idPersona, idPlan);
+    }
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerBloques(Long idPersona, Integer idPlan, Integer semestre) {
+        return bajaUsuarioRepository.obtenerBloques(idPersona, idPlan, semestre);
+    }
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerProgramas(Long idPersona, Integer idPlan, Integer semestre, String bloque) {
+        return bajaUsuarioRepository.obtenerProgramas(idPersona, idPlan, semestre, bloque);
+    }
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerPeriodos(Integer idPlan) {
+        return bajaUsuarioRepository.obtenerPeriodos(idPlan);
+    }
+
+    @Override
+    public List<CatalogoOpcionDTO> obtenerEventos(Integer idPlan, Integer idPrograma) {
+        return bajaUsuarioRepository.obtenerEventos(idPlan, idPrograma);
+    }
+
+    @Override
+    public BajaDetalleDTO obtenerDetalleBaja(Long idPersona, Integer idPlan, Integer idPrograma, Integer idEvento) {
+        return bajaUsuarioRepository.obtenerDetalleBaja(idPersona, idPlan, idPrograma, idEvento);
+    }
+
+    @Override
+    @Transactional(rollbackFor = ServiceException.class)
+    public void aplicarBaja(NuevaBajaDTO nuevaBaja, Long usuarioSesion) throws ServiceException {
+        try {
+            if (StringUtils.isBlank(nuevaBaja.getMatricula())) {
+                throw new ServiceException("La matrícula o usuario es obligatoria", null);
+            }
+
+            Optional<Long> persona = bajaUsuarioRepository.buscarPersonaPorMatricula(nuevaBaja.getMatricula());
+            if (!persona.isPresent()) {
+                throw new ServiceException("No se encontró información de la matrícula proporcionada", null);
+            }
+            nuevaBaja.setIdPersona(persona.get());
+
+            if (nuevaBaja.getIdPlan() == null) {
+                throw new ServiceException("El plan es obligatorio para aplicar la baja", null);
+            }
+
+            Integer procesoId = bajaUsuarioRepository.obtenerProcesoBajas();
+            nuevaBaja.setProcesoId(procesoId != null ? procesoId : 0);
+
+            BajaDetalleDTO detalle = bajaUsuarioRepository.obtenerDetalleBaja(nuevaBaja.getIdPersona(), nuevaBaja.getIdPlan(),
+                    nuevaBaja.getIdPrograma(), nuevaBaja.getIdEvento());
+            if (detalle == null || detalle.getIdPlan() == null || detalle.getIdPrograma() == null || detalle.getIdEvento() == null) {
+                throw new ServiceException("El usuario no cuenta con matriculación para aplicar la baja solicitada", null);
+            }
+
+            nuevaBaja.setIdPlan(detalle.getIdPlan());
+            nuevaBaja.setIdPrograma(detalle.getIdPrograma());
+            nuevaBaja.setIdEvento(detalle.getIdEvento());
+            nuevaBaja.setIdGrupo(detalle.getIdGrupo());
+
+            String descripcion = StringUtils.defaultString(nuevaBaja.getMotivo());
+            if (StringUtils.isNotBlank(nuevaBaja.getNumeroSolicitud())) {
+                descripcion = descripcion + " | Número de solicitud: " + nuevaBaja.getNumeroSolicitud();
+            }
+            if (StringUtils.isNotBlank(nuevaBaja.getQuienAplica())) {
+                descripcion = descripcion + " | Quién aplica: " + nuevaBaja.getQuienAplica();
+            }
+            nuevaBaja.setMotivo(descripcion);
+
+            Integer idMotivo = bajaUsuarioRepository.registrarMotivo(nuevaBaja);
+            nuevaBaja.setIdMotivo(idMotivo);
+
+            bajaUsuarioRepository.registrarBaja(nuevaBaja, usuarioSesion);
+
+        } catch (ServiceException se) {
+            throw se;
+        } catch (Exception e) {
+            throw new ServiceException("Ocurrió un error al aplicar la baja", e);
+        }
+    }
+}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/BajaUsuarioServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/BajaUsuarioServiceImpl.java
@@ -32,33 +32,33 @@ public class BajaUsuarioServiceImpl implements BajaUsuarioService {
     }
 
     @Override
-    public List<CatalogoOpcionDTO> obtenerPlanesPorPersona(Long idPersona) {
-        return bajaUsuarioRepository.obtenerPlanesPorPersona(idPersona);
+    public List<CatalogoOpcionDTO> obtenerPlanes() {
+        return bajaUsuarioRepository.obtenerPlanes();
     }
 
     @Override
-    public List<CatalogoOpcionDTO> obtenerSemestres(Long idPersona, Integer idPlan) {
-        return bajaUsuarioRepository.obtenerSemestres(idPersona, idPlan);
+    public List<CatalogoOpcionDTO> obtenerSemestres(Integer idPlan) {
+        return bajaUsuarioRepository.obtenerSemestres(idPlan);
     }
 
     @Override
-    public List<CatalogoOpcionDTO> obtenerBloques(Long idPersona, Integer idPlan, Integer semestre) {
-        return bajaUsuarioRepository.obtenerBloques(idPersona, idPlan, semestre);
+    public List<CatalogoOpcionDTO> obtenerBloques(Integer idSemestre) {
+        return bajaUsuarioRepository.obtenerBloques(idSemestre);
     }
 
     @Override
-    public List<CatalogoOpcionDTO> obtenerProgramas(Long idPersona, Integer idPlan, Integer semestre, String bloque) {
-        return bajaUsuarioRepository.obtenerProgramas(idPersona, idPlan, semestre, bloque);
+    public List<CatalogoOpcionDTO> obtenerProgramas(Integer idEjeCapacitacion) {
+        return bajaUsuarioRepository.obtenerProgramas(idEjeCapacitacion);
     }
 
     @Override
-    public List<CatalogoOpcionDTO> obtenerPeriodos(Integer idPlan) {
-        return bajaUsuarioRepository.obtenerPeriodos(idPlan);
+    public List<CatalogoOpcionDTO> obtenerPeriodos() {
+        return bajaUsuarioRepository.obtenerPeriodos();
     }
 
     @Override
-    public List<CatalogoOpcionDTO> obtenerEventos(Integer idPlan, Integer idPrograma) {
-        return bajaUsuarioRepository.obtenerEventos(idPlan, idPrograma);
+    public List<CatalogoOpcionDTO> obtenerEventos(String nombrePeriodo, Integer idPrograma) {
+        return bajaUsuarioRepository.obtenerEventos(nombrePeriodo, idPrograma);
     }
 
     @Override

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -18,16 +18,185 @@
                 <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaBaja')}"
                          styleClass="panel-primary">
                     <div class="row">
-                        <div class="col-md-12">
-                            <h:outputText value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.mensaje.pendiente')}" />
+                        <div class="col-md-4">
+                            <p:outputLabel for="matricula" value="Matrícula/Usuario*" />
+                            <p:inputText id="matricula"
+                                         value="#{nuevaBajaBean.nuevaBaja.matricula}"
+                                         styleClass="form-control" />
+                        </div>
+                        <div class="col-md-2" style="margin-top: 22px;">
+                            <p:commandButton value="Buscar"
+                                             actionListener="#{nuevaBajaBean.buscarPorMatricula}"
+                                             process="matricula"
+                                             update="frmNuevaBaja"
+                                             icon="fa fa-search"
+                                             styleClass="btn btn-primary" />
+                        </div>
+                        <div class="col-md-6">
+                            <p:outputLabel for="tipoBaja" value="Tipo de baja*" />
+                            <p:selectOneMenu id="tipoBaja"
+                                             value="#{nuevaBajaBean.nuevaBaja.idTipoBaja}"
+                                             styleClass="form-control"
+                                             panelStyleClass="form-control">
+                                <f:selectItem itemLabel="Seleccione" itemValue="" />
+                                <f:selectItems value="#{nuevaBajaBean.tiposBaja}"
+                                               var="tipo"
+                                               itemLabel="#{tipo.descripcion}"
+                                               itemValue="#{tipo.id}" />
+                            </p:selectOneMenu>
                         </div>
                     </div>
+
                     <div class="row" style="margin-top: 15px;">
+                        <div class="col-md-6">
+                            <p:outputLabel for="plan" value="Plan*" />
+                            <p:selectOneMenu id="plan"
+                                             value="#{nuevaBajaBean.nuevaBaja.idPlan}"
+                                             styleClass="form-control"
+                                             panelStyleClass="form-control"
+                                             disabled="#{empty nuevaBajaBean.planes}"
+                                             required="true"
+                                             converter="javax.faces.Integer">
+                                <f:selectItem itemLabel="Seleccione" itemValue="" />
+                                <f:selectItems value="#{nuevaBajaBean.planes}"
+                                               var="plan"
+                                               itemLabel="#{plan.descripcion}"
+                                               itemValue="#{plan.id != null ? plan.id.intValue() : null}" />
+                                <p:ajax event="change"
+                                        listener="#{nuevaBajaBean.onPlanChange}"
+                                        update="semestre bloque programa periodo evento" />
+                            </p:selectOneMenu>
+                        </div>
+                        <div class="col-md-3">
+                            <p:outputLabel for="semestre" value="Semestre" />
+                            <p:selectOneMenu id="semestre"
+                                             value="#{nuevaBajaBean.nuevaBaja.semestre}"
+                                             styleClass="form-control"
+                                             panelStyleClass="form-control"
+                                             disabled="#{empty nuevaBajaBean.semestres}"
+                                             required="#{nuevaBajaBean.bajaParcialOTemporal}"
+                                             converter="javax.faces.Integer">
+                                <f:selectItem itemLabel="Seleccione" itemValue="" />
+                                <f:selectItems value="#{nuevaBajaBean.semestres}"
+                                               var="sem"
+                                               itemLabel="#{sem.descripcion}"
+                                               itemValue="#{sem.id != null ? sem.id.intValue() : null}" />
+                                <p:ajax event="change"
+                                        listener="#{nuevaBajaBean.onSemestreChange}"
+                                        update="bloque programa evento" />
+                            </p:selectOneMenu>
+                        </div>
+                        <div class="col-md-3">
+                            <p:outputLabel for="bloque" value="Bloque" />
+                            <p:selectOneMenu id="bloque"
+                                             value="#{nuevaBajaBean.nuevaBaja.bloque}"
+                                             styleClass="form-control"
+                                             panelStyleClass="form-control"
+                                             disabled="#{empty nuevaBajaBean.bloques}">
+                                <f:selectItem itemLabel="Seleccione" itemValue="" />
+                                <f:selectItems value="#{nuevaBajaBean.bloques}"
+                                               var="bloque"
+                                               itemLabel="#{bloque.descripcion}"
+                                               itemValue="#{bloque.descripcion}" />
+                                <p:ajax event="change"
+                                        listener="#{nuevaBajaBean.onBloqueChange}"
+                                        update="programa evento" />
+                            </p:selectOneMenu>
+                        </div>
+                    </div>
+
+                    <div class="row" style="margin-top: 15px;">
+                        <div class="col-md-6">
+                            <p:outputLabel for="programa" value="Asignatura/Programa" />
+                            <p:selectOneMenu id="programa"
+                                             value="#{nuevaBajaBean.nuevaBaja.idPrograma}"
+                                             styleClass="form-control"
+                                             panelStyleClass="form-control"
+                                             disabled="#{empty nuevaBajaBean.programas}"
+                                             required="#{nuevaBajaBean.bajaParcialOTemporal}"
+                                             converter="javax.faces.Integer">
+                                <f:selectItem itemLabel="Seleccione" itemValue="" />
+                                <f:selectItems value="#{nuevaBajaBean.programas}"
+                                               var="prog"
+                                               itemLabel="#{prog.descripcion}"
+                                               itemValue="#{prog.id != null ? prog.id.intValue() : null}" />
+                                <p:ajax event="change"
+                                        listener="#{nuevaBajaBean.onProgramaChange}"
+                                        update="evento" />
+                            </p:selectOneMenu>
+                        </div>
+                        <div class="col-md-3">
+                            <p:outputLabel for="periodo" value="Periodo" />
+                            <p:selectOneMenu id="periodo"
+                                             value="#{nuevaBajaBean.nuevaBaja.idPeriodo}"
+                                             styleClass="form-control"
+                                             panelStyleClass="form-control"
+                                             disabled="#{empty nuevaBajaBean.periodos}"
+                                             required="#{nuevaBajaBean.bajaParcialOTemporal}"
+                                             converter="javax.faces.Integer">
+                                <f:selectItem itemLabel="Seleccione" itemValue="" />
+                                <f:selectItems value="#{nuevaBajaBean.periodos}"
+                                               var="per"
+                                               itemLabel="#{per.descripcion}"
+                                               itemValue="#{per.id != null ? per.id.intValue() : null}" />
+                            </p:selectOneMenu>
+                        </div>
+                        <div class="col-md-3">
+                            <p:outputLabel for="evento" value="Evento" />
+                            <p:selectOneMenu id="evento"
+                                             value="#{nuevaBajaBean.nuevaBaja.idEvento}"
+                                             styleClass="form-control"
+                                             panelStyleClass="form-control"
+                                             disabled="#{empty nuevaBajaBean.eventos}"
+                                             converter="javax.faces.Integer">
+                                <f:selectItem itemLabel="Seleccione" itemValue="" />
+                                <f:selectItems value="#{nuevaBajaBean.eventos}"
+                                               var="evt"
+                                               itemLabel="#{evt.descripcion}"
+                                               itemValue="#{evt.id != null ? evt.id.intValue() : null}" />
+                            </p:selectOneMenu>
+                        </div>
+                    </div>
+
+                    <div class="row" style="margin-top: 15px;">
+                        <div class="col-md-12">
+                            <p:outputLabel for="motivo" value="Motivo*" />
+                            <p:inputTextarea id="motivo"
+                                             value="#{nuevaBajaBean.nuevaBaja.motivo}"
+                                             styleClass="form-control"
+                                             rows="3"
+                                             required="true" />
+                        </div>
+                    </div>
+
+                    <div class="row" style="margin-top: 15px;">
+                        <div class="col-md-6">
+                            <p:outputLabel for="quienAplica" value="Quién aplica la baja" />
+                            <p:inputText id="quienAplica"
+                                         value="#{nuevaBajaBean.nuevaBaja.quienAplica}"
+                                         styleClass="form-control" />
+                        </div>
+                        <div class="col-md-6">
+                            <p:outputLabel for="numeroSolicitud" value="Número de solicitud" />
+                            <p:inputText id="numeroSolicitud"
+                                         value="#{nuevaBajaBean.nuevaBaja.numeroSolicitud}"
+                                         styleClass="form-control" />
+                        </div>
+                    </div>
+
+                    <div class="row" style="margin-top: 20px;">
                         <div class="col-md-12 text-right">
+                            <p:commandButton value="Agregar"
+                                             actionListener="#{nuevaBajaBean.aplicarBaja}"
+                                             process="@form"
+                                             update="frmNuevaBaja"
+                                             styleClass="btn btn-primary"
+                                             icon="fa fa-check" />
                             <p:commandButton value="#{sistema.obtenerTexto('gw.ge.texto.regresar')}"
                                              action="#{altasBajasUsuariosBean.regresarAlModulo}"
                                              styleClass="btn btn-default"
-                                             ajax="false" />
+                                             ajax="false"
+                                             icon="fa fa-undo" />
                         </div>
                     </div>
                 </p:panel>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -9,7 +9,7 @@
 
     <ui:fragment rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_BAJ')}">
         <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_BAJ') ">
-            <h:form id="frmNuevaBaja">
+            <h:form id="frmNuevaBaja" styleClass="form-horizontal">
                 <p:messages id="msgsNuevaBaja"
                              autoUpdate="true"
                              closable="true"
@@ -18,26 +18,27 @@
                 <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaBaja')}"
                          styleClass="panel-primary">
                     <div class="row">
-                        <div class="col-md-4">
-                            <p:outputLabel for="matricula" value="Matrícula/Usuario*" />
+                        <div class="col-md-4 form-group">
+                            <p:outputLabel for="matricula" value="Matrícula/Usuario*" styleClass="control-label" />
                             <p:inputText id="matricula"
                                          value="#{nuevaBajaBean.nuevaBaja.matricula}"
-                                         styleClass="form-control" />
+                                         styleClass="form-control"
+                                         style="width: 100%;" />
                         </div>
-                        <div class="col-md-2" style="margin-top: 22px;">
+                        <div class="col-md-2 form-group" style="margin-top: 22px;">
                             <p:commandButton value="Buscar"
                                              actionListener="#{nuevaBajaBean.buscarPorMatricula}"
                                              process="matricula"
                                              update="frmNuevaBaja"
                                              icon="fa fa-search"
-                                             styleClass="btn btn-primary" />
+                                             styleClass="btn btn-primary btn-block" />
                         </div>
-                        <div class="col-md-6">
-                            <p:outputLabel for="tipoBaja" value="Tipo de baja*" />
+                        <div class="col-md-6 form-group">
+                            <p:outputLabel for="tipoBaja" value="Tipo de baja*" styleClass="control-label" />
                             <p:selectOneMenu id="tipoBaja"
                                              value="#{nuevaBajaBean.nuevaBaja.idTipoBaja}"
                                              styleClass="form-control"
-                                             panelStyleClass="form-control">
+                                             style="width: 100%;">
                                 <f:selectItem itemLabel="Seleccione" itemValue="" />
                                 <f:selectItems value="#{nuevaBajaBean.tiposBaja}"
                                                var="tipo"
@@ -47,13 +48,13 @@
                         </div>
                     </div>
 
-                    <div class="row" style="margin-top: 15px;">
-                        <div class="col-md-6">
-                            <p:outputLabel for="plan" value="Plan*" />
+                    <div class="row">
+                        <div class="col-md-6 form-group">
+                            <p:outputLabel for="plan" value="Plan*" styleClass="control-label" />
                             <p:selectOneMenu id="plan"
                                              value="#{nuevaBajaBean.nuevaBaja.idPlan}"
                                              styleClass="form-control"
-                                             panelStyleClass="form-control"
+                                             style="width: 100%;"
                                              disabled="#{empty nuevaBajaBean.planes}"
                                              required="true"
                                              converter="javax.faces.Integer">
@@ -67,12 +68,12 @@
                                         update="semestre bloque programa periodo evento" />
                             </p:selectOneMenu>
                         </div>
-                        <div class="col-md-3">
-                            <p:outputLabel for="semestre" value="Semestre" />
+                        <div class="col-md-3 form-group">
+                            <p:outputLabel for="semestre" value="Semestre" styleClass="control-label" />
                             <p:selectOneMenu id="semestre"
                                              value="#{nuevaBajaBean.nuevaBaja.semestre}"
                                              styleClass="form-control"
-                                             panelStyleClass="form-control"
+                                             style="width: 100%;"
                                              disabled="#{empty nuevaBajaBean.semestres}"
                                              required="#{nuevaBajaBean.bajaParcialOTemporal}"
                                              converter="javax.faces.Integer">
@@ -86,12 +87,12 @@
                                         update="bloque programa evento" />
                             </p:selectOneMenu>
                         </div>
-                        <div class="col-md-3">
-                            <p:outputLabel for="bloque" value="Bloque" />
+                        <div class="col-md-3 form-group">
+                            <p:outputLabel for="bloque" value="Bloque" styleClass="control-label" />
                             <p:selectOneMenu id="bloque"
                                              value="#{nuevaBajaBean.nuevaBaja.bloque}"
                                              styleClass="form-control"
-                                             panelStyleClass="form-control"
+                                             style="width: 100%;"
                                              disabled="#{empty nuevaBajaBean.bloques}">
                                 <f:selectItem itemLabel="Seleccione" itemValue="" />
                                 <f:selectItems value="#{nuevaBajaBean.bloques}"
@@ -105,13 +106,13 @@
                         </div>
                     </div>
 
-                    <div class="row" style="margin-top: 15px;">
-                        <div class="col-md-6">
-                            <p:outputLabel for="programa" value="Asignatura/Programa" />
+                    <div class="row">
+                        <div class="col-md-6 form-group">
+                            <p:outputLabel for="programa" value="Asignatura/Programa" styleClass="control-label" />
                             <p:selectOneMenu id="programa"
                                              value="#{nuevaBajaBean.nuevaBaja.idPrograma}"
                                              styleClass="form-control"
-                                             panelStyleClass="form-control"
+                                             style="width: 100%;"
                                              disabled="#{empty nuevaBajaBean.programas}"
                                              required="#{nuevaBajaBean.bajaParcialOTemporal}"
                                              converter="javax.faces.Integer">
@@ -125,12 +126,12 @@
                                         update="evento" />
                             </p:selectOneMenu>
                         </div>
-                        <div class="col-md-3">
-                            <p:outputLabel for="periodo" value="Periodo" />
+                        <div class="col-md-3 form-group">
+                            <p:outputLabel for="periodo" value="Periodo" styleClass="control-label" />
                             <p:selectOneMenu id="periodo"
                                              value="#{nuevaBajaBean.nuevaBaja.idPeriodo}"
                                              styleClass="form-control"
-                                             panelStyleClass="form-control"
+                                             style="width: 100%;"
                                              disabled="#{empty nuevaBajaBean.periodos}"
                                              required="#{nuevaBajaBean.bajaParcialOTemporal}"
                                              converter="javax.faces.Integer">
@@ -141,12 +142,12 @@
                                                itemValue="#{per.id != null ? per.id.intValue() : null}" />
                             </p:selectOneMenu>
                         </div>
-                        <div class="col-md-3">
-                            <p:outputLabel for="evento" value="Evento" />
+                        <div class="col-md-3 form-group">
+                            <p:outputLabel for="evento" value="Evento" styleClass="control-label" />
                             <p:selectOneMenu id="evento"
                                              value="#{nuevaBajaBean.nuevaBaja.idEvento}"
                                              styleClass="form-control"
-                                             panelStyleClass="form-control"
+                                             style="width: 100%;"
                                              disabled="#{empty nuevaBajaBean.eventos}"
                                              converter="javax.faces.Integer">
                                 <f:selectItem itemLabel="Seleccione" itemValue="" />
@@ -158,33 +159,36 @@
                         </div>
                     </div>
 
-                    <div class="row" style="margin-top: 15px;">
-                        <div class="col-md-12">
-                            <p:outputLabel for="motivo" value="Motivo*" />
+                    <div class="row">
+                        <div class="col-md-12 form-group">
+                            <p:outputLabel for="motivo" value="Motivo*" styleClass="control-label" />
                             <p:inputTextarea id="motivo"
                                              value="#{nuevaBajaBean.nuevaBaja.motivo}"
                                              styleClass="form-control"
+                                             style="width: 100%;"
                                              rows="3"
                                              required="true" />
                         </div>
                     </div>
 
-                    <div class="row" style="margin-top: 15px;">
-                        <div class="col-md-6">
-                            <p:outputLabel for="quienAplica" value="Quién aplica la baja" />
+                    <div class="row">
+                        <div class="col-md-6 form-group">
+                            <p:outputLabel for="quienAplica" value="Quién aplica la baja" styleClass="control-label" />
                             <p:inputText id="quienAplica"
                                          value="#{nuevaBajaBean.nuevaBaja.quienAplica}"
-                                         styleClass="form-control" />
+                                         styleClass="form-control"
+                                         style="width: 100%;" />
                         </div>
-                        <div class="col-md-6">
-                            <p:outputLabel for="numeroSolicitud" value="Número de solicitud" />
+                        <div class="col-md-6 form-group">
+                            <p:outputLabel for="numeroSolicitud" value="Número de solicitud" styleClass="control-label" />
                             <p:inputText id="numeroSolicitud"
                                          value="#{nuevaBajaBean.nuevaBaja.numeroSolicitud}"
-                                         styleClass="form-control" />
+                                         styleClass="form-control"
+                                         style="width: 100%;" />
                         </div>
                     </div>
 
-                    <div class="row" style="margin-top: 20px;">
+                    <div class="row" style="margin-top: 10px;">
                         <div class="col-md-12 text-right">
                             <p:commandButton value="Agregar"
                                              actionListener="#{nuevaBajaBean.aplicarBaja}"

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -93,12 +93,13 @@
                                              value="#{nuevaBajaBean.nuevaBaja.bloque}"
                                              styleClass="form-control"
                                              style="width: 100%;"
-                                             disabled="#{empty nuevaBajaBean.bloques}">
+                                             disabled="#{empty nuevaBajaBean.bloques}"
+                                             converter="javax.faces.Integer">
                                 <f:selectItem itemLabel="Seleccione" itemValue="" />
                                 <f:selectItems value="#{nuevaBajaBean.bloques}"
                                                var="bloque"
                                                itemLabel="#{bloque.descripcion}"
-                                               itemValue="#{bloque.descripcion}" />
+                                               itemValue="#{bloque.id != null ? bloque.id.intValue() : null}" />
                                 <p:ajax event="change"
                                         listener="#{nuevaBajaBean.onBloqueChange}"
                                         update="programa evento" />
@@ -140,6 +141,9 @@
                                                var="per"
                                                itemLabel="#{per.descripcion}"
                                                itemValue="#{per.id != null ? per.id.intValue() : null}" />
+                                <p:ajax event="change"
+                                        listener="#{nuevaBajaBean.onPeriodoChange}"
+                                        update="evento" />
                             </p:selectOneMenu>
                         </div>
                         <div class="col-md-3 form-group">

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
@@ -75,7 +75,7 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         }
 
         nuevaBaja.setIdPersona(persona.get());
-        planes = bajaUsuarioService.obtenerPlanesPorPersona(persona.get());
+        planes = bajaUsuarioService.obtenerPlanes();
         usuarioValidado = true;
 
         if (planes.isEmpty()) {
@@ -95,11 +95,9 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         nuevaBaja.setIdEvento(null);
         nuevaBaja.setIdPeriodo(null);
 
-        if (nuevaBaja.getIdPlan() != null && nuevaBaja.getIdPersona() != null) {
-            semestres = bajaUsuarioService.obtenerSemestres(nuevaBaja.getIdPersona(), nuevaBaja.getIdPlan());
-            periodos = bajaUsuarioService.obtenerPeriodos(nuevaBaja.getIdPlan());
-            programas = bajaUsuarioService.obtenerProgramas(nuevaBaja.getIdPersona(), nuevaBaja.getIdPlan(), null, null);
-            eventos = bajaUsuarioService.obtenerEventos(nuevaBaja.getIdPlan(), null);
+        if (nuevaBaja.getIdPlan() != null) {
+            semestres = bajaUsuarioService.obtenerSemestres(nuevaBaja.getIdPlan());
+            periodos = bajaUsuarioService.obtenerPeriodos();
         }
     }
 
@@ -111,9 +109,9 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         nuevaBaja.setIdPrograma(null);
         nuevaBaja.setIdEvento(null);
 
-        if (camposPlanCompletos()) {
-            bloques = bajaUsuarioService.obtenerBloques(nuevaBaja.getIdPersona(), nuevaBaja.getIdPlan(), nuevaBaja.getSemestre());
-            programas = bajaUsuarioService.obtenerProgramas(nuevaBaja.getIdPersona(), nuevaBaja.getIdPlan(), nuevaBaja.getSemestre(), null);
+        if (nuevaBaja.getSemestre() != null) {
+            bloques = bajaUsuarioService.obtenerBloques(nuevaBaja.getSemestre());
+            programas = bajaUsuarioService.obtenerProgramas(nuevaBaja.getSemestre());
         }
     }
 
@@ -122,16 +120,27 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         eventos.clear();
         nuevaBaja.setIdPrograma(null);
         nuevaBaja.setIdEvento(null);
-        if (camposPlanCompletos()) {
-            programas = bajaUsuarioService.obtenerProgramas(nuevaBaja.getIdPersona(), nuevaBaja.getIdPlan(), nuevaBaja.getSemestre(), nuevaBaja.getBloque());
+        if (nuevaBaja.getBloque() != null) {
+            programas = bajaUsuarioService.obtenerProgramas(nuevaBaja.getBloque());
         }
     }
 
     public void onProgramaChange() {
         eventos.clear();
         nuevaBaja.setIdEvento(null);
-        if (nuevaBaja.getIdPlan() != null && nuevaBaja.getIdPrograma() != null) {
-            eventos = bajaUsuarioService.obtenerEventos(nuevaBaja.getIdPlan(), nuevaBaja.getIdPrograma());
+        if (nuevaBaja.getIdPrograma() != null && nuevaBaja.getIdPeriodo() != null) {
+            String nombrePeriodo = obtenerDescripcionPorId(periodos, nuevaBaja.getIdPeriodo().longValue());
+            eventos = bajaUsuarioService.obtenerEventos(nombrePeriodo, nuevaBaja.getIdPrograma());
+        }
+    }
+
+    public void onPeriodoChange() {
+        eventos.clear();
+        nuevaBaja.setIdEvento(null);
+
+        if (nuevaBaja.getIdPrograma() != null && nuevaBaja.getIdPeriodo() != null) {
+            String nombrePeriodo = obtenerDescripcionPorId(periodos, nuevaBaja.getIdPeriodo().longValue());
+            eventos = bajaUsuarioService.obtenerEventos(nombrePeriodo, nuevaBaja.getIdPrograma());
         }
     }
 
@@ -191,8 +200,15 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
                 .anyMatch(nombre -> StringUtils.containsIgnoreCase(nombre, "parcial") || StringUtils.containsIgnoreCase(nombre, "temporal"));
     }
 
-    private boolean camposPlanCompletos() {
-        return nuevaBaja.getIdPlan() != null && nuevaBaja.getIdPersona() != null && nuevaBaja.getSemestre() != null;
+    private String obtenerDescripcionPorId(List<CatalogoOpcionDTO> opciones, Long idSeleccionado) {
+        if (opciones == null || idSeleccionado == null) {
+            return "";
+        }
+        return opciones.stream()
+                .filter(op -> op.getId() != null && op.getId().equals(idSeleccionado))
+                .map(CatalogoOpcionDTO::getDescripcion)
+                .findFirst()
+                .orElse("");
     }
 
     private void limpiarListasDependientes() {

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
@@ -1,0 +1,285 @@
+package mx.gob.sedesol.gestorweb.beans.gestionescolar;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ManagedProperty;
+import javax.faces.bean.ViewScoped;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.CatalogoOpcionDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.NuevaBajaDTO;
+import mx.gob.sedesol.basegestor.service.ServiceException;
+import mx.gob.sedesol.basegestor.service.gestionescolar.BajaUsuarioService;
+import mx.gob.sedesol.gestorweb.beans.acceso.BaseBean;
+import mx.gob.sedesol.gestorweb.commons.dto.UsuarioSessionDTO;
+
+@ManagedBean
+@ViewScoped
+public class NuevaBajaBean extends BaseBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = Logger.getLogger(NuevaBajaBean.class);
+
+    @ManagedProperty(value = "#{bajaUsuarioService}")
+    private transient BajaUsuarioService bajaUsuarioService;
+
+    private NuevaBajaDTO nuevaBaja;
+    private List<CatalogoOpcionDTO> tiposBaja;
+    private List<CatalogoOpcionDTO> planes;
+    private List<CatalogoOpcionDTO> semestres;
+    private List<CatalogoOpcionDTO> bloques;
+    private List<CatalogoOpcionDTO> programas;
+    private List<CatalogoOpcionDTO> periodos;
+    private List<CatalogoOpcionDTO> eventos;
+    private boolean usuarioValidado;
+
+    @PostConstruct
+    public void init() {
+        nuevaBaja = new NuevaBajaDTO();
+        tiposBaja = new ArrayList<>();
+        planes = new ArrayList<>();
+        semestres = new ArrayList<>();
+        bloques = new ArrayList<>();
+        programas = new ArrayList<>();
+        periodos = new ArrayList<>();
+        eventos = new ArrayList<>();
+        usuarioValidado = false;
+        cargarTiposBaja();
+    }
+
+    public void cargarTiposBaja() {
+        tiposBaja = bajaUsuarioService.obtenerTiposBaja();
+    }
+
+    public void buscarPorMatricula() {
+        limpiarListasDependientes();
+        if (StringUtils.isBlank(nuevaBaja.getMatricula())) {
+            agregarMsgError("Debe capturar la matrícula o usuario", null);
+            usuarioValidado = false;
+            return;
+        }
+
+        Optional<Long> persona = bajaUsuarioService.buscarPersonaPorMatricula(nuevaBaja.getMatricula());
+        if (!persona.isPresent()) {
+            agregarMsgError("No se encontró la matrícula ingresada", null);
+            usuarioValidado = false;
+            return;
+        }
+
+        nuevaBaja.setIdPersona(persona.get());
+        planes = bajaUsuarioService.obtenerPlanesPorPersona(persona.get());
+        usuarioValidado = true;
+
+        if (planes.isEmpty()) {
+            agregarMsgWarn("El usuario no cuenta con planes activos para aplicar baja", null);
+        }
+    }
+
+    public void onPlanChange() {
+        semestres.clear();
+        bloques.clear();
+        programas.clear();
+        periodos.clear();
+        eventos.clear();
+        nuevaBaja.setSemestre(null);
+        nuevaBaja.setBloque(null);
+        nuevaBaja.setIdPrograma(null);
+        nuevaBaja.setIdEvento(null);
+        nuevaBaja.setIdPeriodo(null);
+
+        if (nuevaBaja.getIdPlan() != null && nuevaBaja.getIdPersona() != null) {
+            semestres = bajaUsuarioService.obtenerSemestres(nuevaBaja.getIdPersona(), nuevaBaja.getIdPlan());
+            periodos = bajaUsuarioService.obtenerPeriodos(nuevaBaja.getIdPlan());
+            programas = bajaUsuarioService.obtenerProgramas(nuevaBaja.getIdPersona(), nuevaBaja.getIdPlan(), null, null);
+            eventos = bajaUsuarioService.obtenerEventos(nuevaBaja.getIdPlan(), null);
+        }
+    }
+
+    public void onSemestreChange() {
+        bloques.clear();
+        programas.clear();
+        eventos.clear();
+        nuevaBaja.setBloque(null);
+        nuevaBaja.setIdPrograma(null);
+        nuevaBaja.setIdEvento(null);
+
+        if (camposPlanCompletos()) {
+            bloques = bajaUsuarioService.obtenerBloques(nuevaBaja.getIdPersona(), nuevaBaja.getIdPlan(), nuevaBaja.getSemestre());
+            programas = bajaUsuarioService.obtenerProgramas(nuevaBaja.getIdPersona(), nuevaBaja.getIdPlan(), nuevaBaja.getSemestre(), null);
+        }
+    }
+
+    public void onBloqueChange() {
+        programas.clear();
+        eventos.clear();
+        nuevaBaja.setIdPrograma(null);
+        nuevaBaja.setIdEvento(null);
+        if (camposPlanCompletos()) {
+            programas = bajaUsuarioService.obtenerProgramas(nuevaBaja.getIdPersona(), nuevaBaja.getIdPlan(), nuevaBaja.getSemestre(), nuevaBaja.getBloque());
+        }
+    }
+
+    public void onProgramaChange() {
+        eventos.clear();
+        nuevaBaja.setIdEvento(null);
+        if (nuevaBaja.getIdPlan() != null && nuevaBaja.getIdPrograma() != null) {
+            eventos = bajaUsuarioService.obtenerEventos(nuevaBaja.getIdPlan(), nuevaBaja.getIdPrograma());
+        }
+    }
+
+    public void aplicarBaja() {
+        List<String> errores = new ArrayList<>();
+        if (!usuarioValidado || nuevaBaja.getIdPersona() == null) {
+            errores.add("Debe validar la matrícula antes de aplicar la baja");
+        }
+        if (nuevaBaja.getIdTipoBaja() == null) {
+            errores.add("Seleccione el tipo de baja");
+        }
+        if (nuevaBaja.getIdPlan() == null) {
+            errores.add("Seleccione el plan");
+        }
+        boolean bajaDetallada = isBajaParcialOTemporal();
+        if (bajaDetallada) {
+            if (nuevaBaja.getSemestre() == null) {
+                errores.add("Seleccione el semestre");
+            }
+            if (nuevaBaja.getIdPrograma() == null) {
+                errores.add("Seleccione la asignatura o programa");
+            }
+            if (nuevaBaja.getIdPeriodo() == null) {
+                errores.add("Seleccione el periodo");
+            }
+        }
+        if (StringUtils.isBlank(nuevaBaja.getMotivo())) {
+            errores.add("Capture el motivo de la baja");
+        }
+
+        if (!errores.isEmpty()) {
+            errores.forEach(error -> agregarMsgError(error, null));
+            return;
+        }
+
+        try {
+            UsuarioSessionDTO usuario = getUsuarioEnSession();
+            bajaUsuarioService.aplicarBaja(nuevaBaja, usuario != null ? usuario.getIdPersona() : null);
+            agregarMsgInfo("Baja aplicada correctamente", null);
+            limpiarFormulario();
+        } catch (ServiceException se) {
+            LOGGER.error("Error de negocio al aplicar la baja", se);
+            agregarMsgError(se.getMessage(), null);
+        } catch (Exception e) {
+            LOGGER.error("Error inesperado al aplicar la baja", e);
+            agregarMsgError("No fue posible aplicar la baja. Intente nuevamente.", null);
+        }
+    }
+
+    public boolean isBajaParcialOTemporal() {
+        if (nuevaBaja.getIdTipoBaja() == null) {
+            return false;
+        }
+        return tiposBaja.stream()
+                .filter(tipo -> tipo.getId().equals(nuevaBaja.getIdTipoBaja()))
+                .map(CatalogoOpcionDTO::getDescripcion)
+                .anyMatch(nombre -> StringUtils.containsIgnoreCase(nombre, "parcial") || StringUtils.containsIgnoreCase(nombre, "temporal"));
+    }
+
+    private boolean camposPlanCompletos() {
+        return nuevaBaja.getIdPlan() != null && nuevaBaja.getIdPersona() != null && nuevaBaja.getSemestre() != null;
+    }
+
+    private void limpiarListasDependientes() {
+        planes.clear();
+        semestres.clear();
+        bloques.clear();
+        programas.clear();
+        periodos.clear();
+        eventos.clear();
+    }
+
+    public void limpiarFormulario() {
+        nuevaBaja = new NuevaBajaDTO();
+        limpiarListasDependientes();
+        usuarioValidado = false;
+        cargarTiposBaja();
+    }
+
+    public NuevaBajaDTO getNuevaBaja() {
+        return nuevaBaja;
+    }
+
+    public void setNuevaBaja(NuevaBajaDTO nuevaBaja) {
+        this.nuevaBaja = nuevaBaja;
+    }
+
+    public List<CatalogoOpcionDTO> getTiposBaja() {
+        return tiposBaja;
+    }
+
+    public void setTiposBaja(List<CatalogoOpcionDTO> tiposBaja) {
+        this.tiposBaja = tiposBaja;
+    }
+
+    public List<CatalogoOpcionDTO> getPlanes() {
+        return planes;
+    }
+
+    public void setPlanes(List<CatalogoOpcionDTO> planes) {
+        this.planes = planes;
+    }
+
+    public List<CatalogoOpcionDTO> getSemestres() {
+        return semestres;
+    }
+
+    public void setSemestres(List<CatalogoOpcionDTO> semestres) {
+        this.semestres = semestres;
+    }
+
+    public List<CatalogoOpcionDTO> getBloques() {
+        return bloques;
+    }
+
+    public void setBloques(List<CatalogoOpcionDTO> bloques) {
+        this.bloques = bloques;
+    }
+
+    public List<CatalogoOpcionDTO> getProgramas() {
+        return programas;
+    }
+
+    public void setProgramas(List<CatalogoOpcionDTO> programas) {
+        this.programas = programas;
+    }
+
+    public List<CatalogoOpcionDTO> getPeriodos() {
+        return periodos;
+    }
+
+    public void setPeriodos(List<CatalogoOpcionDTO> periodos) {
+        this.periodos = periodos;
+    }
+
+    public List<CatalogoOpcionDTO> getEventos() {
+        return eventos;
+    }
+
+    public void setEventos(List<CatalogoOpcionDTO> eventos) {
+        this.eventos = eventos;
+    }
+
+    public BajaUsuarioService getBajaUsuarioService() {
+        return bajaUsuarioService;
+    }
+
+    public void setBajaUsuarioService(BajaUsuarioService bajaUsuarioService) {
+        this.bajaUsuarioService = bajaUsuarioService;
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable DTOs and repository/service layer to registrar bajas de usuario con validaciones y manejo transaccional
- expose managed bean and JSF view to capturar datos de nueva baja con catálogos dinámicos y reglas por tipo
- documentar manejo de campos pendientes de Moodle dejando id de enrolamiento en cero

## Testing
- mvn -pl gestorWeb -am -DskipTests compile *(fails: selected project not found in reactor)*
- mvn -DskipTests compile *(fails: unable to download maven-resources-plugin due to 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e5731e414832fb5e843007fe9ab4e)