### PR TITLE
Add loading modal and logging for nueva baja search

### DIFF
--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -44,7 +44,7 @@
                         <div class="col-md-2 form-group" style="margin-top: 22px;">
                             <p:commandButton value="Buscar"
                                              actionListener="#{nuevaBajaBean.buscarPorMatricula}"
-                                             process="matricula"
+                                             process="@form"
                                              update="frmNuevaBaja"
                                              icon="fa fa-search"
                                              styleClass="btn btn-primary btn-block" />

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -10,10 +10,26 @@
     <ui:fragment rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_BAJ')}">
         <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_BAJ') ">
             <h:form id="frmNuevaBaja" styleClass="form-horizontal">
+                <p:ajaxStatus onstart="PF('dialogLayout').show()"
+                             onsuccess="PF('dialogLayout').hide()"
+                             onerror="PF('dialogLayout').hide()" />
                 <p:messages id="msgsNuevaBaja"
                              autoUpdate="true"
                              closable="true"
                              for="@form" />
+
+                <p:dialog id="dlgUsuarioNoEncontrado"
+                          widgetVar="dlgUsuarioNoEncontrado"
+                          header="Usuario no encontrado"
+                          modal="true"
+                          draggable="false"
+                          resizable="false"
+                          closable="true"
+                          appendTo="@(body)">
+                    <h:panelGroup layout="block" styleClass="text-center">
+                        <h:outputText value="#{nuevaBajaBean.mensajeUsuarioNoEncontrado}" />
+                    </h:panelGroup>
+                </p:dialog>
 
                 <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.nuevaBaja')}"
                          styleClass="panel-primary">

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
@@ -64,19 +64,27 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
 
     public void buscarPorMatricula() {
         limpiarListasDependientes();
-        if (StringUtils.isBlank(nuevaBaja.getMatricula())) {
+        usuarioValidado = false;
+        nuevaBaja.setIdPersona(null);
+        String matriculaCapturada = nuevaBaja.getMatricula();
+        LOGGER.info("buscarPorMatricula invocado con valor capturado: '" + matriculaCapturada + "'");
+        String matriculaNormalizada = StringUtils.upperCase(StringUtils.trimToEmpty(matriculaCapturada));
+        nuevaBaja.setMatricula(matriculaNormalizada);
+
+        if (StringUtils.isBlank(matriculaNormalizada)) {
+            LOGGER.warn("Búsqueda cancelada: la matrícula está vacía o en blanco");
             agregarMsgError("Debe capturar la matrícula o usuario", null);
             usuarioValidado = false;
             return;
         }
 
         try {
-            LOGGER.info("Iniciando búsqueda de usuario con matrícula: " + nuevaBaja.getMatricula());
-            Optional<Long> persona = bajaUsuarioService.buscarPersonaPorMatricula(nuevaBaja.getMatricula());
+            LOGGER.info("Iniciando búsqueda de usuario con matrícula normalizada: " + matriculaNormalizada);
+            Optional<Long> persona = bajaUsuarioService.buscarPersonaPorMatricula(matriculaNormalizada);
             if (!persona.isPresent()) {
-                mensajeUsuarioNoEncontrado = "El usuario con matrícula " + nuevaBaja.getMatricula()
+                mensajeUsuarioNoEncontrado = "El usuario con matrícula " + matriculaNormalizada
                         + " no existe en el sistema. Verifique la información.";
-                LOGGER.warn("No se encontró información para la matrícula: " + nuevaBaja.getMatricula());
+                LOGGER.warn("No se encontró información para la matrícula: " + matriculaNormalizada);
                 usuarioValidado = false;
                 RequestContext context = RequestContext.getCurrentInstance();
                 context.update("frmNuevaBaja:dlgUsuarioNoEncontrado");
@@ -85,11 +93,11 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
             }
 
             nuevaBaja.setIdPersona(persona.get());
-            LOGGER.info("Matrícula " + nuevaBaja.getMatricula() + " encontrada con id de persona: " + persona.get());
+            LOGGER.info("Matrícula " + matriculaNormalizada + " encontrada con id de persona: " + persona.get());
             mensajeUsuarioNoEncontrado = "";
             planes = bajaUsuarioService.obtenerPlanes();
             LOGGER.info("Se recuperaron " + (planes != null ? planes.size() : 0)
-                    + " planes activos para la matrícula " + nuevaBaja.getMatricula());
+                    + " planes activos para la matrícula " + matriculaNormalizada);
             usuarioValidado = true;
 
             if (planes.isEmpty()) {

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
@@ -68,8 +68,9 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         nuevaBaja.setIdPersona(null);
         String matriculaCapturada = nuevaBaja.getMatricula();
         LOGGER.info("buscarPorMatricula invocado con valor capturado: '" + matriculaCapturada + "'");
-        String matriculaNormalizada = StringUtils.upperCase(StringUtils.trimToEmpty(matriculaCapturada));
+        String matriculaNormalizada = StringUtils.lowerCase(StringUtils.trimToEmpty(matriculaCapturada));
         nuevaBaja.setMatricula(matriculaNormalizada);
+        LOGGER.info("Matrícula normalizada (minúsculas): '" + matriculaNormalizada + "'");
 
         if (StringUtils.isBlank(matriculaNormalizada)) {
             LOGGER.warn("Búsqueda cancelada: la matrícula está vacía o en blanco");

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
@@ -93,9 +93,6 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
             if (planes.isEmpty()) {
                 agregarMsgWarn("El usuario no cuenta con planes activos para aplicar baja", null);
             }
-        } catch (ServiceException se) {
-            LOGGER.error("Error de servicio al buscar la matrícula " + nuevaBaja.getMatricula(), se);
-            agregarMsgError("Ocurrió un error al recuperar la información del usuario. Intente nuevamente.", null);
         } catch (Exception e) {
             LOGGER.error("Error inesperado al buscar la matrícula " + nuevaBaja.getMatricula(), e);
             agregarMsgError("No fue posible completar la búsqueda. Contacte al administrador del sistema.", null);

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
@@ -12,6 +12,7 @@ import javax.faces.bean.ViewScoped;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
+import org.primefaces.context.RequestContext;
 
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.CatalogoOpcionDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.NuevaBajaDTO;
@@ -40,6 +41,7 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
     private List<CatalogoOpcionDTO> periodos;
     private List<CatalogoOpcionDTO> eventos;
     private boolean usuarioValidado;
+    private String mensajeUsuarioNoEncontrado;
 
     @PostConstruct
     public void init() {
@@ -52,6 +54,7 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         periodos = new ArrayList<>();
         eventos = new ArrayList<>();
         usuarioValidado = false;
+        mensajeUsuarioNoEncontrado = "";
         cargarTiposBaja();
     }
 
@@ -67,19 +70,35 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
             return;
         }
 
-        Optional<Long> persona = bajaUsuarioService.buscarPersonaPorMatricula(nuevaBaja.getMatricula());
-        if (!persona.isPresent()) {
-            agregarMsgError("No se encontró la matrícula ingresada", null);
-            usuarioValidado = false;
-            return;
-        }
+        try {
+            LOGGER.info("Iniciando búsqueda de usuario con matrícula: " + nuevaBaja.getMatricula());
+            Optional<Long> persona = bajaUsuarioService.buscarPersonaPorMatricula(nuevaBaja.getMatricula());
+            if (!persona.isPresent()) {
+                mensajeUsuarioNoEncontrado = "El usuario con matrícula " + nuevaBaja.getMatricula()
+                        + " no existe en el sistema. Verifique la información.";
+                LOGGER.warn("No se encontró información para la matrícula: " + nuevaBaja.getMatricula());
+                usuarioValidado = false;
+                RequestContext.getCurrentInstance().execute("PF('dlgUsuarioNoEncontrado').show();");
+                return;
+            }
 
-        nuevaBaja.setIdPersona(persona.get());
-        planes = bajaUsuarioService.obtenerPlanes();
-        usuarioValidado = true;
+            nuevaBaja.setIdPersona(persona.get());
+            LOGGER.info("Matrícula " + nuevaBaja.getMatricula() + " encontrada con id de persona: " + persona.get());
+            mensajeUsuarioNoEncontrado = "";
+            planes = bajaUsuarioService.obtenerPlanes();
+            LOGGER.info("Se recuperaron " + (planes != null ? planes.size() : 0)
+                    + " planes activos para la matrícula " + nuevaBaja.getMatricula());
+            usuarioValidado = true;
 
-        if (planes.isEmpty()) {
-            agregarMsgWarn("El usuario no cuenta con planes activos para aplicar baja", null);
+            if (planes.isEmpty()) {
+                agregarMsgWarn("El usuario no cuenta con planes activos para aplicar baja", null);
+            }
+        } catch (ServiceException se) {
+            LOGGER.error("Error de servicio al buscar la matrícula " + nuevaBaja.getMatricula(), se);
+            agregarMsgError("Ocurrió un error al recuperar la información del usuario. Intente nuevamente.", null);
+        } catch (Exception e) {
+            LOGGER.error("Error inesperado al buscar la matrícula " + nuevaBaja.getMatricula(), e);
+            agregarMsgError("No fue posible completar la búsqueda. Contacte al administrador del sistema.", null);
         }
     }
 
@@ -224,6 +243,7 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         nuevaBaja = new NuevaBajaDTO();
         limpiarListasDependientes();
         usuarioValidado = false;
+        mensajeUsuarioNoEncontrado = "";
         cargarTiposBaja();
     }
 
@@ -289,6 +309,14 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
 
     public void setEventos(List<CatalogoOpcionDTO> eventos) {
         this.eventos = eventos;
+    }
+
+    public String getMensajeUsuarioNoEncontrado() {
+        return mensajeUsuarioNoEncontrado;
+    }
+
+    public void setMensajeUsuarioNoEncontrado(String mensajeUsuarioNoEncontrado) {
+        this.mensajeUsuarioNoEncontrado = mensajeUsuarioNoEncontrado;
     }
 
     public BajaUsuarioService getBajaUsuarioService() {

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
@@ -11,7 +11,6 @@ import javax.faces.bean.ManagedProperty;
 import javax.faces.bean.ViewScoped;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
 import org.primefaces.context.RequestContext;
 
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.CatalogoOpcionDTO;
@@ -26,8 +25,6 @@ import mx.gob.sedesol.gestorweb.commons.dto.UsuarioSessionDTO;
 public class NuevaBajaBean extends BaseBean implements Serializable {
 
     private static final long serialVersionUID = 1L;
-
-    private static final Logger LOGGER = Logger.getLogger(NuevaBajaBean.class);
 
     @ManagedProperty(value = "#{bajaUsuarioService}")
     private transient BajaUsuarioService bajaUsuarioService;
@@ -67,25 +64,25 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         usuarioValidado = false;
         nuevaBaja.setIdPersona(null);
         String matriculaCapturada = nuevaBaja.getMatricula();
-        LOGGER.info("buscarPorMatricula invocado con valor capturado: '" + matriculaCapturada + "'");
+        System.out.println("buscarPorMatricula invocado con valor capturado: '" + matriculaCapturada + "'");
         String matriculaNormalizada = StringUtils.lowerCase(StringUtils.trimToEmpty(matriculaCapturada));
         nuevaBaja.setMatricula(matriculaNormalizada);
-        LOGGER.info("Matrícula normalizada (minúsculas): '" + matriculaNormalizada + "'");
+        System.out.println("Matrícula normalizada (minúsculas): '" + matriculaNormalizada + "'");
 
         if (StringUtils.isBlank(matriculaNormalizada)) {
-            LOGGER.warn("Búsqueda cancelada: la matrícula está vacía o en blanco");
+            System.out.println("Búsqueda cancelada: la matrícula está vacía o en blanco");
             agregarMsgError("Debe capturar la matrícula o usuario", null);
             usuarioValidado = false;
             return;
         }
 
         try {
-            LOGGER.info("Iniciando búsqueda de usuario con matrícula normalizada: " + matriculaNormalizada);
+            System.out.println("Iniciando búsqueda de usuario con matrícula normalizada: " + matriculaNormalizada);
             Optional<Long> persona = bajaUsuarioService.buscarPersonaPorMatricula(matriculaNormalizada);
             if (!persona.isPresent()) {
                 mensajeUsuarioNoEncontrado = "El usuario con matrícula " + matriculaNormalizada
                         + " no existe en el sistema. Verifique la información.";
-                LOGGER.warn("No se encontró información para la matrícula: " + matriculaNormalizada);
+                System.out.println("No se encontró información para la matrícula: " + matriculaNormalizada);
                 usuarioValidado = false;
                 RequestContext context = RequestContext.getCurrentInstance();
                 context.update("frmNuevaBaja:dlgUsuarioNoEncontrado");
@@ -94,10 +91,10 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
             }
 
             nuevaBaja.setIdPersona(persona.get());
-            LOGGER.info("Matrícula " + matriculaNormalizada + " encontrada con id de persona: " + persona.get());
+            System.out.println("Matrícula " + matriculaNormalizada + " encontrada con id de persona: " + persona.get());
             mensajeUsuarioNoEncontrado = "";
             planes = bajaUsuarioService.obtenerPlanes();
-            LOGGER.info("Se recuperaron " + (planes != null ? planes.size() : 0)
+            System.out.println("Se recuperaron " + (planes != null ? planes.size() : 0)
                     + " planes activos para la matrícula " + matriculaNormalizada);
             usuarioValidado = true;
 
@@ -105,7 +102,8 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
                 agregarMsgWarn("El usuario no cuenta con planes activos para aplicar baja", null);
             }
         } catch (Exception e) {
-            LOGGER.error("Error inesperado al buscar la matrícula " + nuevaBaja.getMatricula(), e);
+            System.out.println("Error inesperado al buscar la matrícula " + nuevaBaja.getMatricula());
+            e.printStackTrace();
             agregarMsgError("No fue posible completar la búsqueda. Contacte al administrador del sistema.", null);
         }
     }
@@ -123,13 +121,13 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         nuevaBaja.setIdPeriodo(null);
 
         if (nuevaBaja.getIdPlan() != null) {
-            LOGGER.info("Cargando semestres y periodos para el plan " + nuevaBaja.getIdPlan());
+            System.out.println("Cargando semestres y periodos para el plan " + nuevaBaja.getIdPlan());
             semestres = bajaUsuarioService.obtenerSemestres(nuevaBaja.getIdPlan());
             periodos = bajaUsuarioService.obtenerPeriodos();
-            LOGGER.info("Semestres obtenidos: " + (semestres != null ? semestres.size() : 0)
+            System.out.println("Semestres obtenidos: " + (semestres != null ? semestres.size() : 0)
                     + ", periodos obtenidos: " + (periodos != null ? periodos.size() : 0));
         } else {
-            LOGGER.info("Sin plan seleccionado, no se cargan semestres ni periodos");
+            System.out.println("Sin plan seleccionado, no se cargan semestres ni periodos");
         }
     }
 
@@ -142,13 +140,13 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         nuevaBaja.setIdEvento(null);
 
         if (nuevaBaja.getSemestre() != null) {
-            LOGGER.info("Cargando bloques y programas para el semestre " + nuevaBaja.getSemestre());
+            System.out.println("Cargando bloques y programas para el semestre " + nuevaBaja.getSemestre());
             bloques = bajaUsuarioService.obtenerBloques(nuevaBaja.getSemestre());
             programas = bajaUsuarioService.obtenerProgramas(nuevaBaja.getSemestre());
-            LOGGER.info("Bloques obtenidos: " + (bloques != null ? bloques.size() : 0)
+            System.out.println("Bloques obtenidos: " + (bloques != null ? bloques.size() : 0)
                     + ", programas obtenidos: " + (programas != null ? programas.size() : 0));
         } else {
-            LOGGER.info("Sin semestre seleccionado, no se cargan bloques ni programas");
+            System.out.println("Sin semestre seleccionado, no se cargan bloques ni programas");
         }
     }
 
@@ -158,11 +156,11 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         nuevaBaja.setIdPrograma(null);
         nuevaBaja.setIdEvento(null);
         if (nuevaBaja.getBloque() != null) {
-            LOGGER.info("Cargando programas para el bloque " + nuevaBaja.getBloque());
+            System.out.println("Cargando programas para el bloque " + nuevaBaja.getBloque());
             programas = bajaUsuarioService.obtenerProgramas(nuevaBaja.getBloque());
-            LOGGER.info("Programas obtenidos: " + (programas != null ? programas.size() : 0));
+            System.out.println("Programas obtenidos: " + (programas != null ? programas.size() : 0));
         } else {
-            LOGGER.info("Sin bloque seleccionado, no se cargan programas");
+            System.out.println("Sin bloque seleccionado, no se cargan programas");
         }
     }
 
@@ -171,11 +169,11 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         nuevaBaja.setIdEvento(null);
         if (nuevaBaja.getIdPrograma() != null && nuevaBaja.getIdPeriodo() != null) {
             String nombrePeriodo = obtenerDescripcionPorId(periodos, nuevaBaja.getIdPeriodo().longValue());
-            LOGGER.info("Cargando eventos para el programa " + nuevaBaja.getIdPrograma() + " y periodo " + nombrePeriodo);
+            System.out.println("Cargando eventos para el programa " + nuevaBaja.getIdPrograma() + " y periodo " + nombrePeriodo);
             eventos = bajaUsuarioService.obtenerEventos(nombrePeriodo, nuevaBaja.getIdPrograma());
-            LOGGER.info("Eventos obtenidos: " + (eventos != null ? eventos.size() : 0));
+            System.out.println("Eventos obtenidos: " + (eventos != null ? eventos.size() : 0));
         } else {
-            LOGGER.info("Sin programa o periodo seleccionado, no se cargan eventos");
+            System.out.println("Sin programa o periodo seleccionado, no se cargan eventos");
         }
     }
 
@@ -185,11 +183,11 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
 
         if (nuevaBaja.getIdPrograma() != null && nuevaBaja.getIdPeriodo() != null) {
             String nombrePeriodo = obtenerDescripcionPorId(periodos, nuevaBaja.getIdPeriodo().longValue());
-            LOGGER.info("Actualizando eventos para el programa " + nuevaBaja.getIdPrograma() + " y periodo " + nombrePeriodo);
+            System.out.println("Actualizando eventos para el programa " + nuevaBaja.getIdPrograma() + " y periodo " + nombrePeriodo);
             eventos = bajaUsuarioService.obtenerEventos(nombrePeriodo, nuevaBaja.getIdPrograma());
-            LOGGER.info("Eventos obtenidos tras cambio de periodo: " + (eventos != null ? eventos.size() : 0));
+            System.out.println("Eventos obtenidos tras cambio de periodo: " + (eventos != null ? eventos.size() : 0));
         } else {
-            LOGGER.info("Sin programa o periodo seleccionado tras el cambio, no se actualizan eventos");
+            System.out.println("Sin programa o periodo seleccionado tras el cambio, no se actualizan eventos");
         }
     }
 
@@ -231,10 +229,12 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
             agregarMsgInfo("Baja aplicada correctamente", null);
             limpiarFormulario();
         } catch (ServiceException se) {
-            LOGGER.error("Error de negocio al aplicar la baja", se);
+            System.out.println("Error de negocio al aplicar la baja: " + se.getMessage());
+            se.printStackTrace();
             agregarMsgError(se.getMessage(), null);
         } catch (Exception e) {
-            LOGGER.error("Error inesperado al aplicar la baja", e);
+            System.out.println("Error inesperado al aplicar la baja: " + e.getMessage());
+            e.printStackTrace();
             agregarMsgError("No fue posible aplicar la baja. Intente nuevamente.", null);
         }
     }

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
@@ -78,7 +78,9 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
                         + " no existe en el sistema. Verifique la información.";
                 LOGGER.warn("No se encontró información para la matrícula: " + nuevaBaja.getMatricula());
                 usuarioValidado = false;
-                RequestContext.getCurrentInstance().execute("PF('dlgUsuarioNoEncontrado').show();");
+                RequestContext context = RequestContext.getCurrentInstance();
+                context.update("frmNuevaBaja:dlgUsuarioNoEncontrado");
+                context.execute("PF('dlgUsuarioNoEncontrado').show();");
                 return;
             }
 
@@ -112,8 +114,13 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         nuevaBaja.setIdPeriodo(null);
 
         if (nuevaBaja.getIdPlan() != null) {
+            LOGGER.info("Cargando semestres y periodos para el plan " + nuevaBaja.getIdPlan());
             semestres = bajaUsuarioService.obtenerSemestres(nuevaBaja.getIdPlan());
             periodos = bajaUsuarioService.obtenerPeriodos();
+            LOGGER.info("Semestres obtenidos: " + (semestres != null ? semestres.size() : 0)
+                    + ", periodos obtenidos: " + (periodos != null ? periodos.size() : 0));
+        } else {
+            LOGGER.info("Sin plan seleccionado, no se cargan semestres ni periodos");
         }
     }
 
@@ -126,8 +133,13 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         nuevaBaja.setIdEvento(null);
 
         if (nuevaBaja.getSemestre() != null) {
+            LOGGER.info("Cargando bloques y programas para el semestre " + nuevaBaja.getSemestre());
             bloques = bajaUsuarioService.obtenerBloques(nuevaBaja.getSemestre());
             programas = bajaUsuarioService.obtenerProgramas(nuevaBaja.getSemestre());
+            LOGGER.info("Bloques obtenidos: " + (bloques != null ? bloques.size() : 0)
+                    + ", programas obtenidos: " + (programas != null ? programas.size() : 0));
+        } else {
+            LOGGER.info("Sin semestre seleccionado, no se cargan bloques ni programas");
         }
     }
 
@@ -137,7 +149,11 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         nuevaBaja.setIdPrograma(null);
         nuevaBaja.setIdEvento(null);
         if (nuevaBaja.getBloque() != null) {
+            LOGGER.info("Cargando programas para el bloque " + nuevaBaja.getBloque());
             programas = bajaUsuarioService.obtenerProgramas(nuevaBaja.getBloque());
+            LOGGER.info("Programas obtenidos: " + (programas != null ? programas.size() : 0));
+        } else {
+            LOGGER.info("Sin bloque seleccionado, no se cargan programas");
         }
     }
 
@@ -146,7 +162,11 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         nuevaBaja.setIdEvento(null);
         if (nuevaBaja.getIdPrograma() != null && nuevaBaja.getIdPeriodo() != null) {
             String nombrePeriodo = obtenerDescripcionPorId(periodos, nuevaBaja.getIdPeriodo().longValue());
+            LOGGER.info("Cargando eventos para el programa " + nuevaBaja.getIdPrograma() + " y periodo " + nombrePeriodo);
             eventos = bajaUsuarioService.obtenerEventos(nombrePeriodo, nuevaBaja.getIdPrograma());
+            LOGGER.info("Eventos obtenidos: " + (eventos != null ? eventos.size() : 0));
+        } else {
+            LOGGER.info("Sin programa o periodo seleccionado, no se cargan eventos");
         }
     }
 
@@ -156,7 +176,11 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
 
         if (nuevaBaja.getIdPrograma() != null && nuevaBaja.getIdPeriodo() != null) {
             String nombrePeriodo = obtenerDescripcionPorId(periodos, nuevaBaja.getIdPeriodo().longValue());
+            LOGGER.info("Actualizando eventos para el programa " + nuevaBaja.getIdPrograma() + " y periodo " + nombrePeriodo);
             eventos = bajaUsuarioService.obtenerEventos(nombrePeriodo, nuevaBaja.getIdPrograma());
+            LOGGER.info("Eventos obtenidos tras cambio de periodo: " + (eventos != null ? eventos.size() : 0));
+        } else {
+            LOGGER.info("Sin programa o periodo seleccionado tras el cambio, no se actualizan eventos");
         }
     }
 


### PR DESCRIPTION
## Summary
- display the standard loading dialog while interacting with the nueva baja form and add a modal for missing matriculas
- extend nueva baja search logic with detailed logs, error handling, and user-facing messaging

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920d7806324832fa8b2ce7c2a6ba89f)