### PR TITLE
Ocultar campos de detalle para bajas definitivas

### DIFF
--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -51,29 +51,31 @@
                         </div>
                     </div>
 
-                    <div class="row">
-                        <div class="col-md-6 form-group">
-                            <p:outputLabel for="plan" value="Plan*" styleClass="control-label" />
-                            <p:selectOneMenu id="plan"
-                                             value="#{nuevaBajaBean.nuevaBaja.idPlan}"
-                                             styleClass="form-control"
-                                             style="width: 100%;"
-                                             disabled="#{empty nuevaBajaBean.planes}"
-                                             required="true"
-                                             converter="javax.faces.Integer">
-                                <f:selectItem itemLabel="Seleccione" itemValue="" />
-                                <f:selectItems value="#{nuevaBajaBean.planes}"
-                                               var="plan"
-                                               itemLabel="#{plan.descripcion}"
-                                               itemValue="#{plan.id != null ? plan.id.intValue() : null}" />
-                                <p:ajax event="change"
-                                        listener="#{nuevaBajaBean.onPlanChange}"
-                                        update="detallesBaja" />
-                            </p:selectOneMenu>
+                    <p:outputPanel rendered="#{nuevaBajaBean.usuarioValidado}" layout="block">
+                        <div class="row">
+                            <div class="col-md-6 form-group">
+                                <p:outputLabel for="plan" value="Plan*" styleClass="control-label" />
+                                <p:selectOneMenu id="plan"
+                                                 value="#{nuevaBajaBean.nuevaBaja.idPlan}"
+                                                 styleClass="form-control"
+                                                 style="width: 100%;"
+                                                 disabled="#{empty nuevaBajaBean.planes}"
+                                                 required="true"
+                                                 converter="javax.faces.Integer">
+                                    <f:selectItem itemLabel="Seleccione" itemValue="" />
+                                    <f:selectItems value="#{nuevaBajaBean.planes}"
+                                                   var="plan"
+                                                   itemLabel="#{plan.descripcion}"
+                                                   itemValue="#{plan.id != null ? plan.id.intValue() : null}" />
+                                    <p:ajax event="change"
+                                            listener="#{nuevaBajaBean.onPlanChange}"
+                                            update="detallesBaja" />
+                                </p:selectOneMenu>
+                            </div>
                         </div>
-                    </div>
+                    </p:outputPanel>
 
-                    <p:outputPanel id="detallesBaja" layout="block" rendered="#{nuevaBajaBean.bajaParcialOTemporal}">
+                    <p:outputPanel id="detallesBaja" layout="block" rendered="#{nuevaBajaBean.bajaParcialOTemporal and nuevaBajaBean.usuarioValidado}">
                         <div class="row">
                             <div class="col-md-3 form-group">
                                 <p:outputLabel for="semestre" value="Semestre" styleClass="control-label" />

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -44,6 +44,9 @@
                                                var="tipo"
                                                itemLabel="#{tipo.descripcion}"
                                                itemValue="#{tipo.id}" />
+                                <p:ajax event="change"
+                                        listener="#{nuevaBajaBean.onTipoBajaChange}"
+                                        update="detallesBaja" />
                             </p:selectOneMenu>
                         </div>
                     </div>
@@ -65,103 +68,107 @@
                                                itemValue="#{plan.id != null ? plan.id.intValue() : null}" />
                                 <p:ajax event="change"
                                         listener="#{nuevaBajaBean.onPlanChange}"
-                                        update="semestre bloque programa periodo evento" />
-                            </p:selectOneMenu>
-                        </div>
-                        <div class="col-md-3 form-group">
-                            <p:outputLabel for="semestre" value="Semestre" styleClass="control-label" />
-                            <p:selectOneMenu id="semestre"
-                                             value="#{nuevaBajaBean.nuevaBaja.semestre}"
-                                             styleClass="form-control"
-                                             style="width: 100%;"
-                                             disabled="#{empty nuevaBajaBean.semestres}"
-                                             required="#{nuevaBajaBean.bajaParcialOTemporal}"
-                                             converter="javax.faces.Integer">
-                                <f:selectItem itemLabel="Seleccione" itemValue="" />
-                                <f:selectItems value="#{nuevaBajaBean.semestres}"
-                                               var="sem"
-                                               itemLabel="#{sem.descripcion}"
-                                               itemValue="#{sem.id != null ? sem.id.intValue() : null}" />
-                                <p:ajax event="change"
-                                        listener="#{nuevaBajaBean.onSemestreChange}"
-                                        update="bloque programa evento" />
-                            </p:selectOneMenu>
-                        </div>
-                        <div class="col-md-3 form-group">
-                            <p:outputLabel for="bloque" value="Bloque" styleClass="control-label" />
-                            <p:selectOneMenu id="bloque"
-                                             value="#{nuevaBajaBean.nuevaBaja.bloque}"
-                                             styleClass="form-control"
-                                             style="width: 100%;"
-                                             disabled="#{empty nuevaBajaBean.bloques}"
-                                             converter="javax.faces.Integer">
-                                <f:selectItem itemLabel="Seleccione" itemValue="" />
-                                <f:selectItems value="#{nuevaBajaBean.bloques}"
-                                               var="bloque"
-                                               itemLabel="#{bloque.descripcion}"
-                                               itemValue="#{bloque.id != null ? bloque.id.intValue() : null}" />
-                                <p:ajax event="change"
-                                        listener="#{nuevaBajaBean.onBloqueChange}"
-                                        update="programa evento" />
+                                        update="detallesBaja" />
                             </p:selectOneMenu>
                         </div>
                     </div>
 
-                    <div class="row">
-                        <div class="col-md-6 form-group">
-                            <p:outputLabel for="programa" value="Asignatura/Programa" styleClass="control-label" />
-                            <p:selectOneMenu id="programa"
-                                             value="#{nuevaBajaBean.nuevaBaja.idPrograma}"
-                                             styleClass="form-control"
-                                             style="width: 100%;"
-                                             disabled="#{empty nuevaBajaBean.programas}"
-                                             required="#{nuevaBajaBean.bajaParcialOTemporal}"
-                                             converter="javax.faces.Integer">
-                                <f:selectItem itemLabel="Seleccione" itemValue="" />
-                                <f:selectItems value="#{nuevaBajaBean.programas}"
-                                               var="prog"
-                                               itemLabel="#{prog.descripcion}"
-                                               itemValue="#{prog.id != null ? prog.id.intValue() : null}" />
-                                <p:ajax event="change"
-                                        listener="#{nuevaBajaBean.onProgramaChange}"
-                                        update="evento" />
-                            </p:selectOneMenu>
+                    <p:outputPanel id="detallesBaja" layout="block" rendered="#{nuevaBajaBean.bajaParcialOTemporal}">
+                        <div class="row">
+                            <div class="col-md-3 form-group">
+                                <p:outputLabel for="semestre" value="Semestre" styleClass="control-label" />
+                                <p:selectOneMenu id="semestre"
+                                                 value="#{nuevaBajaBean.nuevaBaja.semestre}"
+                                                 styleClass="form-control"
+                                                 style="width: 100%;"
+                                                 disabled="#{empty nuevaBajaBean.semestres}"
+                                                 required="#{nuevaBajaBean.bajaParcialOTemporal}"
+                                                 converter="javax.faces.Integer">
+                                    <f:selectItem itemLabel="Seleccione" itemValue="" />
+                                    <f:selectItems value="#{nuevaBajaBean.semestres}"
+                                                   var="sem"
+                                                   itemLabel="#{sem.descripcion}"
+                                                   itemValue="#{sem.id != null ? sem.id.intValue() : null}" />
+                                    <p:ajax event="change"
+                                            listener="#{nuevaBajaBean.onSemestreChange}"
+                                            update="detallesBaja" />
+                                </p:selectOneMenu>
+                            </div>
+                            <div class="col-md-3 form-group">
+                                <p:outputLabel for="bloque" value="Bloque" styleClass="control-label" />
+                                <p:selectOneMenu id="bloque"
+                                                 value="#{nuevaBajaBean.nuevaBaja.bloque}"
+                                                 styleClass="form-control"
+                                                 style="width: 100%;"
+                                                 disabled="#{empty nuevaBajaBean.bloques}"
+                                                 converter="javax.faces.Integer">
+                                    <f:selectItem itemLabel="Seleccione" itemValue="" />
+                                    <f:selectItems value="#{nuevaBajaBean.bloques}"
+                                                   var="bloque"
+                                                   itemLabel="#{bloque.descripcion}"
+                                                   itemValue="#{bloque.id != null ? bloque.id.intValue() : null}" />
+                                    <p:ajax event="change"
+                                            listener="#{nuevaBajaBean.onBloqueChange}"
+                                            update="detallesBaja" />
+                                </p:selectOneMenu>
+                            </div>
                         </div>
-                        <div class="col-md-3 form-group">
-                            <p:outputLabel for="periodo" value="Periodo" styleClass="control-label" />
-                            <p:selectOneMenu id="periodo"
-                                             value="#{nuevaBajaBean.nuevaBaja.idPeriodo}"
-                                             styleClass="form-control"
-                                             style="width: 100%;"
-                                             disabled="#{empty nuevaBajaBean.periodos}"
-                                             required="#{nuevaBajaBean.bajaParcialOTemporal}"
-                                             converter="javax.faces.Integer">
-                                <f:selectItem itemLabel="Seleccione" itemValue="" />
-                                <f:selectItems value="#{nuevaBajaBean.periodos}"
-                                               var="per"
-                                               itemLabel="#{per.descripcion}"
-                                               itemValue="#{per.id != null ? per.id.intValue() : null}" />
-                                <p:ajax event="change"
-                                        listener="#{nuevaBajaBean.onPeriodoChange}"
-                                        update="evento" />
-                            </p:selectOneMenu>
+                        <div class="row">
+                            <div class="col-md-6 form-group">
+                                <p:outputLabel for="programa" value="Asignatura/Programa" styleClass="control-label" />
+                                <p:selectOneMenu id="programa"
+                                                 value="#{nuevaBajaBean.nuevaBaja.idPrograma}"
+                                                 styleClass="form-control"
+                                                 style="width: 100%;"
+                                                 disabled="#{empty nuevaBajaBean.programas}"
+                                                 required="#{nuevaBajaBean.bajaParcialOTemporal}"
+                                                 converter="javax.faces.Integer">
+                                    <f:selectItem itemLabel="Seleccione" itemValue="" />
+                                    <f:selectItems value="#{nuevaBajaBean.programas}"
+                                                   var="prog"
+                                                   itemLabel="#{prog.descripcion}"
+                                                   itemValue="#{prog.id != null ? prog.id.intValue() : null}" />
+                                    <p:ajax event="change"
+                                            listener="#{nuevaBajaBean.onProgramaChange}"
+                                            update="evento" />
+                                </p:selectOneMenu>
+                            </div>
+                            <div class="col-md-3 form-group">
+                                <p:outputLabel for="periodo" value="Periodo" styleClass="control-label" />
+                                <p:selectOneMenu id="periodo"
+                                                 value="#{nuevaBajaBean.nuevaBaja.idPeriodo}"
+                                                 styleClass="form-control"
+                                                 style="width: 100%;"
+                                                 disabled="#{empty nuevaBajaBean.periodos}"
+                                                 required="#{nuevaBajaBean.bajaParcialOTemporal}"
+                                                 converter="javax.faces.Integer">
+                                    <f:selectItem itemLabel="Seleccione" itemValue="" />
+                                    <f:selectItems value="#{nuevaBajaBean.periodos}"
+                                                   var="per"
+                                                   itemLabel="#{per.descripcion}"
+                                                   itemValue="#{per.id != null ? per.id.intValue() : null}" />
+                                    <p:ajax event="change"
+                                            listener="#{nuevaBajaBean.onPeriodoChange}"
+                                            update="evento" />
+                                </p:selectOneMenu>
+                            </div>
+                            <div class="col-md-3 form-group">
+                                <p:outputLabel for="evento" value="Evento" styleClass="control-label" />
+                                <p:selectOneMenu id="evento"
+                                                 value="#{nuevaBajaBean.nuevaBaja.idEvento}"
+                                                 styleClass="form-control"
+                                                 style="width: 100%;"
+                                                 disabled="#{empty nuevaBajaBean.eventos}"
+                                                 converter="javax.faces.Integer">
+                                    <f:selectItem itemLabel="Seleccione" itemValue="" />
+                                    <f:selectItems value="#{nuevaBajaBean.eventos}"
+                                                   var="evt"
+                                                   itemLabel="#{evt.descripcion}"
+                                                   itemValue="#{evt.id != null ? evt.id.intValue() : null}" />
+                                </p:selectOneMenu>
+                            </div>
                         </div>
-                        <div class="col-md-3 form-group">
-                            <p:outputLabel for="evento" value="Evento" styleClass="control-label" />
-                            <p:selectOneMenu id="evento"
-                                             value="#{nuevaBajaBean.nuevaBaja.idEvento}"
-                                             styleClass="form-control"
-                                             style="width: 100%;"
-                                             disabled="#{empty nuevaBajaBean.eventos}"
-                                             converter="javax.faces.Integer">
-                                <f:selectItem itemLabel="Seleccione" itemValue="" />
-                                <f:selectItems value="#{nuevaBajaBean.eventos}"
-                                               var="evt"
-                                               itemLabel="#{evt.descripcion}"
-                                               itemValue="#{evt.id != null ? evt.id.intValue() : null}" />
-                            </p:selectOneMenu>
-                        </div>
-                    </div>
+                    </p:outputPanel>
 
                     <div class="row">
                         <div class="col-md-12 form-group">

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
@@ -73,7 +73,7 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
     }
 
     public void buscarPorMatricula() {
-        limpiarListasDependientes();
+        prepararNuevaBusqueda();
         if (StringUtils.isBlank(nuevaBaja.getMatricula())) {
             agregarMsgError("Debe capturar la matrícula o usuario", null);
             usuarioValidado = false;
@@ -266,11 +266,17 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         limpiarDetallesBaja();
     }
 
+    private void prepararNuevaBusqueda() {
+        limpiarListasDependientes();
+        nuevaBaja.setIdTipoBaja(null);
+        nuevaBaja.setIdPlan(null);
+        bajaParcialOTemporal = false;
+        usuarioValidado = false;
+    }
+
     public void limpiarFormulario() {
         nuevaBaja = new NuevaBajaDTO();
-        limpiarListasDependientes();
-        usuarioValidado = false;
-        bajaParcialOTemporal = false;
+        prepararNuevaBusqueda();
         cargarTiposBaja();
     }
 

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
@@ -59,6 +59,21 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         tiposBaja = bajaUsuarioService.obtenerTiposBaja();
     }
 
+    public void onTipoBajaChange() {
+        if (!isBajaParcialOTemporal()) {
+            nuevaBaja.setSemestre(null);
+            nuevaBaja.setBloque(null);
+            nuevaBaja.setIdPrograma(null);
+            nuevaBaja.setIdEvento(null);
+            nuevaBaja.setIdPeriodo(null);
+            semestres.clear();
+            bloques.clear();
+            programas.clear();
+            periodos.clear();
+            eventos.clear();
+        }
+    }
+
     public void buscarPorMatricula() {
         limpiarListasDependientes();
         if (StringUtils.isBlank(nuevaBaja.getMatricula())) {

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
@@ -40,6 +40,7 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
     private List<CatalogoOpcionDTO> periodos;
     private List<CatalogoOpcionDTO> eventos;
     private boolean usuarioValidado;
+    private boolean bajaParcialOTemporal;
 
     @PostConstruct
     public void init() {
@@ -52,6 +53,7 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         periodos = new ArrayList<>();
         eventos = new ArrayList<>();
         usuarioValidado = false;
+        bajaParcialOTemporal = false;
         cargarTiposBaja();
     }
 
@@ -60,18 +62,14 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
     }
 
     public void onTipoBajaChange() {
-        if (!isBajaParcialOTemporal()) {
-            nuevaBaja.setSemestre(null);
-            nuevaBaja.setBloque(null);
-            nuevaBaja.setIdPrograma(null);
-            nuevaBaja.setIdEvento(null);
-            nuevaBaja.setIdPeriodo(null);
-            semestres.clear();
-            bloques.clear();
-            programas.clear();
-            periodos.clear();
-            eventos.clear();
+        bajaParcialOTemporal = esBajaParcialOTemporalSeleccionada();
+
+        if (!bajaParcialOTemporal) {
+            limpiarDetallesBaja();
+            return;
         }
+
+        prepararListasDetalle();
     }
 
     public void buscarPorMatricula() {
@@ -99,43 +97,34 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
     }
 
     public void onPlanChange() {
-        semestres.clear();
-        bloques.clear();
-        programas.clear();
-        periodos.clear();
-        eventos.clear();
-        nuevaBaja.setSemestre(null);
-        nuevaBaja.setBloque(null);
-        nuevaBaja.setIdPrograma(null);
-        nuevaBaja.setIdEvento(null);
-        nuevaBaja.setIdPeriodo(null);
+        limpiarDetallesBaja();
 
-        if (nuevaBaja.getIdPlan() != null) {
+        if (bajaParcialOTemporal && nuevaBaja.getIdPlan() != null) {
             semestres = bajaUsuarioService.obtenerSemestres(nuevaBaja.getIdPlan());
             periodos = bajaUsuarioService.obtenerPeriodos();
         }
     }
 
     public void onSemestreChange() {
-        bloques.clear();
-        programas.clear();
-        eventos.clear();
         nuevaBaja.setBloque(null);
         nuevaBaja.setIdPrograma(null);
         nuevaBaja.setIdEvento(null);
+        bloques.clear();
+        programas.clear();
+        eventos.clear();
 
-        if (nuevaBaja.getSemestre() != null) {
+        if (bajaParcialOTemporal && nuevaBaja.getSemestre() != null) {
             bloques = bajaUsuarioService.obtenerBloques(nuevaBaja.getSemestre());
             programas = bajaUsuarioService.obtenerProgramas(nuevaBaja.getSemestre());
         }
     }
 
     public void onBloqueChange() {
-        programas.clear();
-        eventos.clear();
         nuevaBaja.setIdPrograma(null);
         nuevaBaja.setIdEvento(null);
-        if (nuevaBaja.getBloque() != null) {
+        programas.clear();
+        eventos.clear();
+        if (bajaParcialOTemporal && nuevaBaja.getBloque() != null) {
             programas = bajaUsuarioService.obtenerProgramas(nuevaBaja.getBloque());
         }
     }
@@ -143,7 +132,7 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
     public void onProgramaChange() {
         eventos.clear();
         nuevaBaja.setIdEvento(null);
-        if (nuevaBaja.getIdPrograma() != null && nuevaBaja.getIdPeriodo() != null) {
+        if (bajaParcialOTemporal && nuevaBaja.getIdPrograma() != null && nuevaBaja.getIdPeriodo() != null) {
             String nombrePeriodo = obtenerDescripcionPorId(periodos, nuevaBaja.getIdPeriodo().longValue());
             eventos = bajaUsuarioService.obtenerEventos(nombrePeriodo, nuevaBaja.getIdPrograma());
         }
@@ -153,7 +142,7 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         eventos.clear();
         nuevaBaja.setIdEvento(null);
 
-        if (nuevaBaja.getIdPrograma() != null && nuevaBaja.getIdPeriodo() != null) {
+        if (bajaParcialOTemporal && nuevaBaja.getIdPrograma() != null && nuevaBaja.getIdPeriodo() != null) {
             String nombrePeriodo = obtenerDescripcionPorId(periodos, nuevaBaja.getIdPeriodo().longValue());
             eventos = bajaUsuarioService.obtenerEventos(nombrePeriodo, nuevaBaja.getIdPrograma());
         }
@@ -161,6 +150,7 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
 
     public void aplicarBaja() {
         List<String> errores = new ArrayList<>();
+        bajaParcialOTemporal = esBajaParcialOTemporalSeleccionada();
         if (!usuarioValidado || nuevaBaja.getIdPersona() == null) {
             errores.add("Debe validar la matrícula antes de aplicar la baja");
         }
@@ -170,7 +160,7 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         if (nuevaBaja.getIdPlan() == null) {
             errores.add("Seleccione el plan");
         }
-        boolean bajaDetallada = isBajaParcialOTemporal();
+        boolean bajaDetallada = bajaParcialOTemporal;
         if (bajaDetallada) {
             if (nuevaBaja.getSemestre() == null) {
                 errores.add("Seleccione el semestre");
@@ -206,6 +196,38 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
     }
 
     public boolean isBajaParcialOTemporal() {
+        return bajaParcialOTemporal;
+    }
+
+    private void prepararListasDetalle() {
+        if (nuevaBaja.getIdPlan() == null) {
+            limpiarDetallesBaja();
+            return;
+        }
+
+        if (semestres.isEmpty()) {
+            semestres = bajaUsuarioService.obtenerSemestres(nuevaBaja.getIdPlan());
+        }
+        if (periodos.isEmpty()) {
+            periodos = bajaUsuarioService.obtenerPeriodos();
+        }
+        if (nuevaBaja.getSemestre() != null) {
+            if (bloques.isEmpty()) {
+                bloques = bajaUsuarioService.obtenerBloques(nuevaBaja.getSemestre());
+            }
+            if (programas.isEmpty()) {
+                programas = nuevaBaja.getBloque() != null
+                        ? bajaUsuarioService.obtenerProgramas(nuevaBaja.getBloque())
+                        : bajaUsuarioService.obtenerProgramas(nuevaBaja.getSemestre());
+            }
+        }
+        if (nuevaBaja.getIdPrograma() != null && nuevaBaja.getIdPeriodo() != null) {
+            String nombrePeriodo = obtenerDescripcionPorId(periodos, nuevaBaja.getIdPeriodo().longValue());
+            eventos = bajaUsuarioService.obtenerEventos(nombrePeriodo, nuevaBaja.getIdPrograma());
+        }
+    }
+
+    private boolean esBajaParcialOTemporalSeleccionada() {
         if (nuevaBaja.getIdTipoBaja() == null) {
             return false;
         }
@@ -213,6 +235,19 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
                 .filter(tipo -> tipo.getId().equals(nuevaBaja.getIdTipoBaja()))
                 .map(CatalogoOpcionDTO::getDescripcion)
                 .anyMatch(nombre -> StringUtils.containsIgnoreCase(nombre, "parcial") || StringUtils.containsIgnoreCase(nombre, "temporal"));
+    }
+
+    private void limpiarDetallesBaja() {
+        nuevaBaja.setSemestre(null);
+        nuevaBaja.setBloque(null);
+        nuevaBaja.setIdPrograma(null);
+        nuevaBaja.setIdPeriodo(null);
+        nuevaBaja.setIdEvento(null);
+        semestres.clear();
+        bloques.clear();
+        programas.clear();
+        periodos.clear();
+        eventos.clear();
     }
 
     private String obtenerDescripcionPorId(List<CatalogoOpcionDTO> opciones, Long idSeleccionado) {
@@ -228,17 +263,14 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
 
     private void limpiarListasDependientes() {
         planes.clear();
-        semestres.clear();
-        bloques.clear();
-        programas.clear();
-        periodos.clear();
-        eventos.clear();
+        limpiarDetallesBaja();
     }
 
     public void limpiarFormulario() {
         nuevaBaja = new NuevaBajaDTO();
         limpiarListasDependientes();
         usuarioValidado = false;
+        bajaParcialOTemporal = false;
         cargarTiposBaja();
     }
 

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaBean.java
@@ -338,6 +338,14 @@ public class NuevaBajaBean extends BaseBean implements Serializable {
         this.eventos = eventos;
     }
 
+    public boolean isUsuarioValidado() {
+        return usuarioValidado;
+    }
+
+    public void setUsuarioValidado(boolean usuarioValidado) {
+        this.usuarioValidado = usuarioValidado;
+    }
+
     public BajaUsuarioService getBajaUsuarioService() {
         return bajaUsuarioService;
     }


### PR DESCRIPTION
## Summary
- ocultar los campos de semestre, bloque, programa, periodo y evento cuando la baja no es parcial o temporal
- limpiar selecciones dependientes al cambiar el tipo de baja
- actualizar el formulario para volver a renderizar los campos cuando aplique

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69234b7f19ec832f8cef6fcab672bffb)