### PR TITLE
Add consulta de bajas form and backend search

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/ConsultaBajaDTO.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/ConsultaBajaDTO.java
@@ -1,0 +1,77 @@
+package mx.gob.sedesol.basegestor.commons.dto.gestionescolar;
+
+public class ConsultaBajaDTO {
+
+    private String matricula;
+    private String plan;
+    private String programa;
+    private String evento;
+    private String tipoBaja;
+    private String estructura;
+    private String periodo;
+    private Integer estatus;
+
+    public String getMatricula() {
+        return matricula;
+    }
+
+    public void setMatricula(String matricula) {
+        this.matricula = matricula;
+    }
+
+    public String getPlan() {
+        return plan;
+    }
+
+    public void setPlan(String plan) {
+        this.plan = plan;
+    }
+
+    public String getPrograma() {
+        return programa;
+    }
+
+    public void setPrograma(String programa) {
+        this.programa = programa;
+    }
+
+    public String getEvento() {
+        return evento;
+    }
+
+    public void setEvento(String evento) {
+        this.evento = evento;
+    }
+
+    public String getTipoBaja() {
+        return tipoBaja;
+    }
+
+    public void setTipoBaja(String tipoBaja) {
+        this.tipoBaja = tipoBaja;
+    }
+
+    public String getEstructura() {
+        return estructura;
+    }
+
+    public void setEstructura(String estructura) {
+        this.estructura = estructura;
+    }
+
+    public String getPeriodo() {
+        return periodo;
+    }
+
+    public void setPeriodo(String periodo) {
+        this.periodo = periodo;
+    }
+
+    public Integer getEstatus() {
+        return estatus;
+    }
+
+    public void setEstatus(Integer estatus) {
+        this.estatus = estatus;
+    }
+}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/ConsultaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/ConsultaBajaRepository.java
@@ -1,0 +1,70 @@
+package mx.gob.sedesol.basegestor.model.repositories.gestionescolar;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
+import mx.gob.sedesol.basegestor.commons.utils.ObjectUtils;
+
+@Repository
+public class ConsultaBajaRepository implements IConsultaBajaRepository {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Override
+    public List<ConsultaBajaDTO> buscarBajas(String matricula, Integer idPeriodo, Integer estatus) {
+
+        String consulta = "SELECT p.sso_idUsuario AS matricula, "
+                + " pl.nombre AS plan, "
+                + " fdp.nombre_tentativo AS programa, "
+                + " e.nombre_ec AS evento, "
+                + " ctb.nombre AS tipo_baja, "
+                + " rmp.nombre_estructuras AS estructura, "
+                + " cp.nombre AS periodo, "
+                + " rpb.contabilizar AS estatus "
+                + "FROM rel_persona_bajas rpb "
+                + " INNER JOIN tbl_persona p ON p.id_persona = rpb.id_persona "
+                + " INNER JOIN tbl_planes pl ON pl.id_plan = rpb.id_plan "
+                + " INNER JOIN tbl_ficha_descriptiva_programa fdp ON fdp.id_programa = rpb.id_programa "
+                + " INNER JOIN tbl_eventos e ON e.id_evento = rpb.id_evento "
+                + " INNER JOIN rel_motivo_baja rmb ON rmb.id_motivo_baja = rpb.motivo_baja_id "
+                + " INNER JOIN cat_tipo_bajas ctb ON ctb.id_tipo_baja = rmb.tipo_baja_id "
+                + " LEFT JOIN rel_malla_plan rmp ON rmp.id_plan = pl.id_plan "
+                + " LEFT JOIN cat_periodos cp ON cp.id_periodo = pl.id_periodo "
+                + "WHERE p.sso_idUsuario LIKE :matricula "
+                + " AND pl.id_periodo = :idPeriodo "
+                + " AND rpb.contabilizar = :estatus";
+
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("matricula", '%' + matricula + '%');
+        query.setParameter("idPeriodo", idPeriodo);
+        query.setParameter("estatus", estatus);
+
+        List<Object[]> resultados = query.getResultList();
+        List<ConsultaBajaDTO> bajas = new ArrayList<>();
+
+        if (!ObjectUtils.isNullOrEmpty(resultados)) {
+            for (Object[] registro : resultados) {
+                ConsultaBajaDTO dto = new ConsultaBajaDTO();
+                dto.setMatricula(registro[0] != null ? registro[0].toString() : "");
+                dto.setPlan(registro[1] != null ? registro[1].toString() : "");
+                dto.setPrograma(registro[2] != null ? registro[2].toString() : "");
+                dto.setEvento(registro[3] != null ? registro[3].toString() : "");
+                dto.setTipoBaja(registro[4] != null ? registro[4].toString() : "");
+                dto.setEstructura(registro[5] != null ? registro[5].toString() : "");
+                dto.setPeriodo(registro[6] != null ? registro[6].toString() : "");
+                dto.setEstatus(registro[7] != null ? Integer.valueOf(registro[7].toString()) : null);
+                bajas.add(dto);
+            }
+        }
+
+        return bajas;
+    }
+}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/IConsultaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/IConsultaBajaRepository.java
@@ -1,0 +1,10 @@
+package mx.gob.sedesol.basegestor.model.repositories.gestionescolar;
+
+import java.util.List;
+
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
+
+public interface IConsultaBajaRepository {
+
+    List<ConsultaBajaDTO> buscarBajas(String matricula, Integer idPeriodo, Integer estatus);
+}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/ConsultaBajaService.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/ConsultaBajaService.java
@@ -1,0 +1,10 @@
+package mx.gob.sedesol.basegestor.service.gestionescolar;
+
+import java.util.List;
+
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
+
+public interface ConsultaBajaService {
+
+    List<ConsultaBajaDTO> buscarBajas(String matricula, Integer idPeriodo, Integer estatus);
+}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/ConsultaBajaServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/ConsultaBajaServiceImpl.java
@@ -1,0 +1,31 @@
+package mx.gob.sedesol.basegestor.service.impl.gestionescolar;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
+import mx.gob.sedesol.basegestor.model.repositories.gestionescolar.IConsultaBajaRepository;
+import mx.gob.sedesol.basegestor.service.gestionescolar.ConsultaBajaService;
+
+@Service("consultaBajaService")
+public class ConsultaBajaServiceImpl implements ConsultaBajaService {
+
+    private static final Logger LOGGER = Logger.getLogger(ConsultaBajaServiceImpl.class);
+
+    @Autowired
+    private IConsultaBajaRepository consultaBajaRepository;
+
+    @Override
+    public List<ConsultaBajaDTO> buscarBajas(String matricula, Integer idPeriodo, Integer estatus) {
+        try {
+            return consultaBajaRepository.buscarBajas(matricula, idPeriodo, estatus);
+        } catch (Exception ex) {
+            LOGGER.error("Error al consultar bajas de usuarios", ex);
+            return new ArrayList<>();
+        }
+    }
+}

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -17,17 +17,151 @@
 
                 <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.consultarBaja')}"
                          styleClass="panel-primary">
-                    <div class="row">
-                        <div class="col-md-12">
-                            <h:outputText value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.mensaje.pendiente')}" />
+                    <div class="form-group">
+                        <div class="row">
+                            <div class="col-md-4 col-xs-12">
+                                <p:outputLabel for="matricula"
+                                               styleClass="bloque requerido"
+                                               value="Matrícula/Usuario:" />
+                                <p:inputText id="matricula"
+                                             value="#{consultaBajaUsuariosBean.matricula}"
+                                             styleClass="form-control"
+                                             required="true"
+                                             requiredMessage="La matrícula o usuario es obligatorio." />
+                                <p:message for="matricula" display="text" />
+                            </div>
+
+                            <div class="col-md-4 col-xs-12">
+                                <p:outputLabel for="periodo"
+                                               styleClass="bloque requerido"
+                                               value="Periodo:" />
+                                <p:selectOneMenu id="periodo"
+                                                 value="#{consultaBajaUsuariosBean.periodoSeleccionado}"
+                                                 styleClass="col-xs-12"
+                                                 required="true"
+                                                 requiredMessage="El periodo es obligatorio.">
+                                    <p:ajax event="change" process="@this" />
+                                    <f:selectItem itemLabel="#{sistema.obtenerTexto('gw.textos.menu.seleccionar')}" itemValue="#{null}" />
+                                    <f:selectItems value="#{consultaBajaUsuariosBean.periodos}"
+                                                   var="periodo"
+                                                   itemLabel="#{periodo.nombre}"
+                                                   itemValue="#{periodo.id}" />
+                                </p:selectOneMenu>
+                                <p:message for="periodo" display="text" />
+                            </div>
+
+                            <div class="col-md-4 col-xs-12">
+                                <p:outputLabel for="estatus"
+                                               styleClass="bloque requerido"
+                                               value="Estatus*" />
+                                <p:selectOneMenu id="estatus"
+                                                 value="#{consultaBajaUsuariosBean.estatusSeleccionado}"
+                                                 styleClass="col-xs-12"
+                                                 required="true"
+                                                 requiredMessage="El estatus es obligatorio.">
+                                    <p:ajax event="change" process="@this" />
+                                    <f:selectItem itemLabel="#{sistema.obtenerTexto('gw.textos.menu.seleccionar')}" itemValue="#{null}" />
+                                    <f:selectItem itemLabel="Aplicada" itemValue="1" />
+                                    <f:selectItem itemLabel="Pendiente" itemValue="0" />
+                                </p:selectOneMenu>
+                                <p:message for="estatus" display="text" />
+                            </div>
                         </div>
                     </div>
-                    <div class="row" style="margin-top: 15px;">
-                        <div class="col-md-12 text-right">
-                            <p:commandButton value="#{sistema.obtenerTexto('gw.ge.texto.regresar')}"
-                                             action="#{altasBajasUsuariosBean.regresarAlModulo}"
-                                             styleClass="btn btn-default"
-                                             ajax="false" />
+
+                    <div class="form-group">
+                        <div class="row">
+                            <div class="col-md-12 text-right">
+                                <p:commandButton value="#{sistema.obtenerTexto('gw.ge.texto.regresar')}"
+                                                 action="#{altasBajasUsuariosBean.regresarAlModulo}"
+                                                 styleClass="btn btn-default"
+                                                 ajax="false" />
+
+                                <p:commandButton value="Limpiar campos"
+                                                 actionListener="#{consultaBajaUsuariosBean.limpiar}"
+                                                 process="@this"
+                                                 update="@form"
+                                                 styleClass="btn btn-default" />
+
+                                <p:commandButton id="btnBuscarBajas"
+                                                 process="@form"
+                                                 ajax="true"
+                                                 update="@form"
+                                                 styleClass="btn btn-primary pull-right"
+                                                 actionListener="#{consultaBajaUsuariosBean.buscar}"
+                                                 value="#{sistema.obtenerTexto('gw.ga.btn.buscar')}" />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-12">
+                            <p:dataTable id="tablaBajas"
+                                         value="#{consultaBajaUsuariosBean.resultados}"
+                                         var="baja"
+                                         paginator="true"
+                                         rows="10"
+                                         paginatorPosition="bottom"
+                                         emptyMessage="No se encontraron registros"
+                                         tableStyleClass="table"
+                                         reflow="true">
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Matrícula" />
+                                    </f:facet>
+                                    <h:outputText value="#{baja.matricula}" />
+                                </p:column>
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Plan" />
+                                    </f:facet>
+                                    <h:outputText value="#{baja.plan}" />
+                                </p:column>
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Programa" />
+                                    </f:facet>
+                                    <h:outputText value="#{baja.programa}" />
+                                </p:column>
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Evento" />
+                                    </f:facet>
+                                    <h:outputText value="#{baja.evento}" />
+                                </p:column>
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Tipo de baja" />
+                                    </f:facet>
+                                    <h:outputText value="#{baja.tipoBaja}" />
+                                </p:column>
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Estructura" />
+                                    </f:facet>
+                                    <h:outputText value="#{baja.estructura}" />
+                                </p:column>
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Periodo" />
+                                    </f:facet>
+                                    <h:outputText value="#{baja.periodo}" />
+                                </p:column>
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Estatus" />
+                                    </f:facet>
+                                    <h:outputText value="#{consultaBajaUsuariosBean.obtenerNombreEstatus(baja.estatus)}" />
+                                </p:column>
+                            </p:dataTable>
                         </div>
                     </div>
                 </p:panel>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -53,7 +53,7 @@
                             <div class="col-md-4 col-xs-12">
                                 <p:outputLabel for="estatus"
                                                styleClass="bloque requerido"
-                                               value="Estatus*" />
+                                               value="Estatus" />
                                 <p:selectOneMenu id="estatus"
                                                  value="#{consultaBajaUsuariosBean.estatusSeleccionado}"
                                                  styleClass="col-xs-12"
@@ -72,10 +72,6 @@
                     <div class="form-group">
                         <div class="row">
                             <div class="col-md-12 text-right">
-                                <p:commandButton value="#{sistema.obtenerTexto('gw.ge.texto.regresar')}"
-                                                 action="#{altasBajasUsuariosBean.regresarAlModulo}"
-                                                 styleClass="btn btn-default"
-                                                 ajax="false" />
 
                                 <p:commandButton value="Limpiar campos"
                                                  actionListener="#{consultaBajaUsuariosBean.limpiar}"

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/ConsultaBajaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/ConsultaBajaUsuariosBean.java
@@ -1,0 +1,149 @@
+package mx.gob.sedesol.gestorweb.beans.gestionescolar;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ManagedProperty;
+import javax.faces.bean.ViewScoped;
+
+import org.apache.log4j.Logger;
+
+import mx.gob.sedesol.basegestor.commons.dto.admin.CatalogoComunDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
+import mx.gob.sedesol.basegestor.commons.utils.ObjectUtils;
+import mx.gob.sedesol.basegestor.service.gestionescolar.ConsultaBajaService;
+import mx.gob.sedesol.gestorweb.beans.acceso.BaseBean;
+import mx.gob.sedesol.gestorweb.commons.constantes.ConstantesGestorWeb;
+
+@ManagedBean
+@ViewScoped
+public class ConsultaBajaUsuariosBean extends BaseBean {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = Logger.getLogger(ConsultaBajaUsuariosBean.class);
+
+    @ManagedProperty(value = "#{consultaBajaService}")
+    private transient ConsultaBajaService consultaBajaService;
+
+    private String matricula;
+    private Integer periodoSeleccionado;
+    private Integer estatusSeleccionado;
+    private List<CatalogoComunDTO> periodos;
+    private List<ConsultaBajaDTO> resultados;
+
+    @PostConstruct
+    public void init() {
+        LOGGER.info("Inicializando consulta de bajas de usuarios");
+        resultados = new ArrayList<>();
+        cargarPeriodos();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void cargarPeriodos() {
+        periodos = (List<CatalogoComunDTO>) getSession().getServletContext()
+                .getAttribute(ConstantesGestorWeb.CAT_PERIODOS);
+        if (periodos == null) {
+            periodos = new ArrayList<>();
+        }
+    }
+
+    public void buscar() {
+        if (!validarCampos()) {
+            return;
+        }
+
+        resultados = consultaBajaService.buscarBajas(matricula.trim(), periodoSeleccionado, estatusSeleccionado);
+
+        if (ObjectUtils.isNullOrEmpty(resultados)) {
+            agregarMsgInfo("No se encontraron registros", null);
+        }
+    }
+
+    public void limpiar() {
+        matricula = null;
+        periodoSeleccionado = null;
+        estatusSeleccionado = null;
+        resultados = new ArrayList<>();
+    }
+
+    public String obtenerNombreEstatus(Integer estatus) {
+        if (estatus != null && estatus == 1) {
+            return "Aplicada";
+        }
+        return "Pendiente";
+    }
+
+    private boolean validarCampos() {
+        boolean valido = true;
+
+        if (ObjectUtils.isNullOrEmpty(matricula) || matricula.trim().isEmpty()) {
+            agregarMsgError("La matrícula o usuario es obligatorio.", null);
+            valido = false;
+        } else {
+            matricula = matricula.trim();
+        }
+
+        if (ObjectUtils.isNullOrEmpty(periodoSeleccionado)) {
+            agregarMsgError("El periodo es obligatorio.", null);
+            valido = false;
+        }
+
+        if (ObjectUtils.isNullOrEmpty(estatusSeleccionado)) {
+            agregarMsgError("El estatus es obligatorio.", null);
+            valido = false;
+        }
+
+        return valido;
+    }
+
+    public String getMatricula() {
+        return matricula;
+    }
+
+    public void setMatricula(String matricula) {
+        this.matricula = matricula;
+    }
+
+    public Integer getPeriodoSeleccionado() {
+        return periodoSeleccionado;
+    }
+
+    public void setPeriodoSeleccionado(Integer periodoSeleccionado) {
+        this.periodoSeleccionado = periodoSeleccionado;
+    }
+
+    public Integer getEstatusSeleccionado() {
+        return estatusSeleccionado;
+    }
+
+    public void setEstatusSeleccionado(Integer estatusSeleccionado) {
+        this.estatusSeleccionado = estatusSeleccionado;
+    }
+
+    public List<CatalogoComunDTO> getPeriodos() {
+        return periodos;
+    }
+
+    public void setPeriodos(List<CatalogoComunDTO> periodos) {
+        this.periodos = periodos;
+    }
+
+    public List<ConsultaBajaDTO> getResultados() {
+        return resultados;
+    }
+
+    public void setResultados(List<ConsultaBajaDTO> resultados) {
+        this.resultados = resultados;
+    }
+
+    public ConsultaBajaService getConsultaBajaService() {
+        return consultaBajaService;
+    }
+
+    public void setConsultaBajaService(ConsultaBajaService consultaBajaService) {
+        this.consultaBajaService = consultaBajaService;
+    }
+}


### PR DESCRIPTION
## Summary
- add DTO, repository, and service to query bajas by matrícula, periodo, y estatus
- create managed bean and PrimeFaces form to search bajas with required validations and empty-state messaging
- render results table showing baja details and status labels

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924f85732dc832fb656187a28e4f244)