### PR TITLE
Actualiza modales de Nueva Baja

### DIFF
--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -217,18 +217,12 @@
                     </div>
                 </p:panel>
 
-                <p:ajaxStatus onstart="PF('dlgNuevaBajaCargando').show()" onsuccess="PF('dlgNuevaBajaCargando').hide()" />
+                <p:ajaxStatus onstart="PF('dialogLayout').show()" onsuccess="PF('dialogLayout').hide()" />
 
-                <p:dialog appendTo="@(body)" draggable="false" position="center"
-                          resizable="false" closable="false" modal="true" width="400px"
-                          widgetVar="dlgNuevaBajaCargando" header="Cargando" dynamic="true">
-                    <div class="form-group">
-                        <div class="row">
-                            <div class="col-md-12">
-                                <h:outputText styleClass="bloque" value="Procesando, por favor espere..." />
-                            </div>
-                        </div>
-                    </div>
+                <p:dialog modal="true" appendTo="@(body)" widgetVar="dialogLayout"
+                          header="Cargando" draggable="false" closable="false" resizable="false"
+                          style="text-align: center;" dynamic="true">
+                    <p:graphicImage library="images" name="ajax-loader.gif" />
                 </p:dialog>
 
                 <p:dialog appendTo="@(body)" draggable="false" position="center"

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -260,7 +260,10 @@
                     <div class="row">
                         <div class="col-md-12 text-right">
                             <p:commandButton value="Cerrar" styleClass="btn btn-default"
-                                             onclick="PF('dlgNuevaBajaExito').hide()" />
+                                             process="@this"
+                                             update="@form"
+                                             actionListener="#{nuevaBajaUsuarioBean.limpiarFormulario}"
+                                             oncomplete="PF('dlgNuevaBajaExito').hide()" />
                         </div>
                     </div>
                 </p:dialog>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -260,9 +260,6 @@
                     <div class="row">
                         <div class="col-md-12 text-right">
                             <p:commandButton value="Cerrar" styleClass="btn btn-default"
-                                             process="@this"
-                                             update="@form"
-                                             actionListener="#{nuevaBajaUsuarioBean.limpiarFormulario}"
                                              oncomplete="PF('dlgNuevaBajaExito').hide()" />
                         </div>
                     </div>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -216,6 +216,80 @@
                         </div>
                     </div>
                 </p:panel>
+
+                <p:ajaxStatus onstart="PF('dlgNuevaBajaCargando').show()" onsuccess="PF('dlgNuevaBajaCargando').hide()" />
+
+                <p:dialog appendTo="@(body)" draggable="false" position="center"
+                          resizable="false" closable="false" modal="true" width="400px"
+                          widgetVar="dlgNuevaBajaCargando" header="Cargando" dynamic="true">
+                    <div class="form-group">
+                        <div class="row">
+                            <div class="col-md-12">
+                                <h:outputText styleClass="bloque" value="Procesando, por favor espere..." />
+                            </div>
+                        </div>
+                    </div>
+                </p:dialog>
+
+                <p:dialog appendTo="@(body)" draggable="false" position="center"
+                          resizable="false" closable="false" modal="true" width="600px"
+                          widgetVar="dlgNuevaBajaValidacion" header="Informativo" dynamic="true">
+                    <div class="form-group">
+                        <div class="row">
+                            <div class="col-md-12">
+                                <h:outputText styleClass="bloque"
+                                              value="Ingrese los datos marcados como obligatorios." />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-12 text-right">
+                            <p:commandButton value="Cerrar" styleClass="btn btn-default"
+                                             onclick="PF('dlgNuevaBajaValidacion').hide()" />
+                        </div>
+                    </div>
+                </p:dialog>
+
+                <p:dialog appendTo="@(body)" draggable="false" position="center"
+                          resizable="false" closable="false" modal="true" width="600px"
+                          widgetVar="dlgNuevaBajaExito" header="Informativo" dynamic="true">
+                    <div class="form-group">
+                        <div class="row">
+                            <div class="col-md-12">
+                                <h:outputText styleClass="bloque"
+                                              value="#{nuevaBajaUsuarioBean.mensajeExitoDialogo}" />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-12 text-right">
+                            <p:commandButton value="Cerrar" styleClass="btn btn-default"
+                                             onclick="PF('dlgNuevaBajaExito').hide()" />
+                        </div>
+                    </div>
+                </p:dialog>
+
+                <p:dialog appendTo="@(body)" draggable="false" position="center"
+                          resizable="false" closable="false" modal="true" width="600px"
+                          widgetVar="dlgNuevaBajaError" header="Informativo" dynamic="true">
+                    <div class="form-group">
+                        <div class="row">
+                            <div class="col-md-12">
+                                <h:outputText styleClass="bloque"
+                                              value="#{nuevaBajaUsuarioBean.mensajeErrorDialogo}" />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-12 text-right">
+                            <p:commandButton value="Cerrar" styleClass="btn btn-default"
+                                             onclick="PF('dlgNuevaBajaError').hide()" />
+                        </div>
+                    </div>
+                </p:dialog>
             </h:form>
         </sec:authorize>
     </ui:fragment>

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
@@ -141,8 +141,8 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
             BajaSolicitudDTO solicitud = construirSolicitud();
             nuevaBajaService.aplicarBaja(solicitud);
             mensajeExitoDialogo = "Baja aplicada correctamente";
-            mostrarDialogo("dlgNuevaBajaExito");
             limpiarFormulario();
+            mostrarDialogo("dlgNuevaBajaExito");
         } catch (IllegalArgumentException ex) {
             mensajeErrorDialogo = ex.getMessage();
             mostrarDialogo("dlgNuevaBajaError");

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
@@ -11,6 +11,7 @@ import javax.faces.bean.ViewScoped;
 import javax.faces.model.SelectItem;
 
 import org.apache.log4j.Logger;
+import org.primefaces.context.RequestContext;
 
 import mx.gob.sedesol.basegestor.commons.dto.NodoDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaSolicitudDTO;
@@ -52,6 +53,8 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
     private boolean mostrarPrograma;
     private boolean mostrarPeriodo;
     private boolean mostrarEvento;
+    private String mensajeErrorDialogo;
+    private String mensajeExitoDialogo;
     private boolean esTipoDefinitiva;
     private boolean esTipoTemporalOParcial;
     private boolean esSinAsignaturas;
@@ -129,21 +132,29 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
         }
 
         if (!errores.isEmpty()) {
-            errores.forEach(error -> agregarMsgError(error, null));
+            mensajeErrorDialogo = "Ingrese los datos marcados como obligatorios.";
+            mostrarDialogo("dlgNuevaBajaValidacion");
             return;
         }
 
         try {
             BajaSolicitudDTO solicitud = construirSolicitud();
             nuevaBajaService.aplicarBaja(solicitud);
-            agregarMsgInfo("Baja aplicada correctamente", null);
+            mensajeExitoDialogo = "Baja aplicada correctamente";
+            mostrarDialogo("dlgNuevaBajaExito");
             limpiarFormulario();
         } catch (IllegalArgumentException ex) {
-            agregarMsgError(ex.getMessage(), null);
+            mensajeErrorDialogo = ex.getMessage();
+            mostrarDialogo("dlgNuevaBajaError");
         } catch (Exception ex) {
             LOGGER.error("Error al registrar la baja", ex);
-            agregarMsgError("Ocurrió un error al registrar la baja", null);
+            mensajeErrorDialogo = "Ocurrió un error al registrar la baja";
+            mostrarDialogo("dlgNuevaBajaError");
         }
+    }
+
+    private void mostrarDialogo(String widgetVar) {
+        RequestContext.getCurrentInstance().execute("PF('" + widgetVar + "').show()");
     }
 
     public void limpiarFormulario() {
@@ -492,6 +503,22 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
 
     public void setEventos(List<SelectItem> eventos) {
         this.eventos = eventos;
+    }
+
+    public String getMensajeErrorDialogo() {
+        return mensajeErrorDialogo;
+    }
+
+    public void setMensajeErrorDialogo(String mensajeErrorDialogo) {
+        this.mensajeErrorDialogo = mensajeErrorDialogo;
+    }
+
+    public String getMensajeExitoDialogo() {
+        return mensajeExitoDialogo;
+    }
+
+    public void setMensajeExitoDialogo(String mensajeExitoDialogo) {
+        this.mensajeExitoDialogo = mensajeExitoDialogo;
     }
 
     public boolean isMostrarSemestre() {


### PR DESCRIPTION
## Summary
- agrega diálogos modales de validación, carga y resultado en la pantalla de Nueva Baja para alinearse con Nueva Convocatoria
- ajusta NuevaBajaUsuarioBean para mostrar los nuevos modales y comunicar mensajes de éxito o error

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69273ec6c3f8832fb8225f93261c3826)