### PR TITLE
Corrige carga de plan y malla curricular en nueva baja

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
@@ -39,7 +39,9 @@ public class NuevaBajaRepository implements INuevaBajaRepository {
     @SuppressWarnings("unchecked")
     @Override
     public List<PlanBajaDTO> consultarPlanesActivos() {
-        String consulta = "SELECT tmc.id, tmc.id_plan, tmc.nombre FROM tbl_malla_curricular tmc WHERE tmc.activo = 1 AND tmc.id_plan IS NOT NULL";
+        String consulta = "SELECT tmc.id, tmc.id_plan, tmc.nombre "
+                + "FROM tbl_malla_curricular tmc "
+                + "WHERE tmc.activo = 1 AND tmc.id_plan IS NOT NULL AND tmc.id_padre IS NULL";
         Query query = entityManager.createNativeQuery(consulta);
         List<Object[]> resultados = query.getResultList();
         List<PlanBajaDTO> planes = new ArrayList<>();
@@ -53,7 +55,12 @@ public class NuevaBajaRepository implements INuevaBajaRepository {
     @SuppressWarnings("unchecked")
     @Override
     public List<NodoDTO> consultarSemestresPorPlan(Long idPlan) {
-        String consulta = "SELECT tmc.id, tmc.nombre FROM tbl_malla_curricular tmc WHERE tmc.id_plan = :idPlan";
+        String consulta = "SELECT hijo.id, hijo.nombre "
+                + "FROM tbl_malla_curricular hijo "
+                + "WHERE hijo.id_padre = (";
+        consulta += "    SELECT plan.id FROM tbl_malla_curricular plan "
+                + "    WHERE plan.id_plan = :idPlan AND plan.id_padre IS NULL LIMIT 1";
+        consulta += " ) AND hijo.activo = 1";
         Query query = entityManager.createNativeQuery(consulta);
         query.setParameter("idPlan", idPlan);
         List<Object[]> resultados = query.getResultList();
@@ -68,7 +75,8 @@ public class NuevaBajaRepository implements INuevaBajaRepository {
     @SuppressWarnings("unchecked")
     @Override
     public List<NodoDTO> consultarBloquesPorSemestre(Long idSemestre) {
-        String consulta = "SELECT tmc.id, tmc.nombre FROM tbl_malla_curricular tmc WHERE tmc.id_padre = :idSemestre";
+        String consulta = "SELECT tmc.id, tmc.nombre FROM tbl_malla_curricular tmc "
+                + "WHERE tmc.id_padre = :idSemestre AND tmc.activo = 1";
         Query query = entityManager.createNativeQuery(consulta);
         query.setParameter("idSemestre", idSemestre);
         List<Object[]> resultados = query.getResultList();
@@ -224,20 +232,20 @@ public class NuevaBajaRepository implements INuevaBajaRepository {
     @SuppressWarnings("unchecked")
     public BajaMatriculaDetalleDTO consultarDatosPorMatricula(String matricula) {
         String consulta = "SELECT DISTINCT "
-                + " tpl.id_plan, "
+                + " tpa.id_plan, "
                 + " sem.id as id_semestre, "
                 + " bloque.id as id_bloque, "
                 + " tfdp.id_programa, "
                 + " tpi.nombre_periodo, "
                 + " te.id_evento "
                 + "FROM tbl_persona tp "
-                + "JOIN rel_grupo_participante rgp ON rgp.id_persona_participante = tp.id_persona "
-                + "JOIN tbl_grupos tg ON tg.id = rgp.id_grupo "
-                + "JOIN tbl_eventos te ON te.id_evento = tg.id_evento "
-                + "JOIN tbl_ficha_descriptiva_programa tfdp ON tfdp.id_programa = te.id_programa "
+                + "JOIN tbl_persona_aspirante tpa ON tpa.id_persona = tp.id_persona "
+                + "LEFT JOIN rel_grupo_participante rgp ON rgp.id_persona_participante = tp.id_persona "
+                + "LEFT JOIN tbl_grupos tg ON tg.id = rgp.id_grupo "
+                + "LEFT JOIN tbl_eventos te ON te.id_evento = tg.id_evento "
+                + "LEFT JOIN tbl_ficha_descriptiva_programa tfdp ON tfdp.id_programa = te.id_programa "
                 + "LEFT JOIN tbl_malla_curricular bloque ON bloque.id = tfdp.id_eje_capacitacion "
                 + "LEFT JOIN tbl_malla_curricular sem ON sem.id = bloque.id_padre "
-                + "LEFT JOIN tbl_planes tpl ON tpl.id_plan = tfdp.id_plan "
                 + "LEFT JOIN tbl_periodos_inscripcion tpi ON te.cve_evento_cap LIKE CONCAT('%', tpi.nombre_periodo, '%') "
                 + "WHERE tp.sso_idUsuario = :matricula "
                 + "ORDER BY te.id_evento DESC "

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
@@ -58,21 +58,7 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
 
     @Override
     public BajaMatriculaDetalleDTO obtenerDatosPorMatricula(String matricula) {
-        BajaMatriculaDetalleDTO datos = nuevaBajaRepository.consultarDatosPorMatricula(matricula);
-
-        if (datos == null) {
-            return null;
-        }
-
-        boolean relacionCompleta = datos.getIdPlan() != null
-                && datos.getIdSemestre() != null
-                && datos.getIdBloque() != null
-                && datos.getIdPrograma() != null
-                && datos.getIdEvento() != null
-                && datos.getPeriodo() != null
-                && !datos.getPeriodo().trim().isEmpty();
-
-        return relacionCompleta ? datos : null;
+        return nuevaBajaRepository.consultarDatosPorMatricula(matricula);
     }
 
     @Override

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
@@ -101,17 +101,32 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
             }
 
             idPlan = datos.getIdPlan();
-            semestres = obtenerSemestres(idPlan);
+            semestres = idPlan != null ? obtenerSemestres(idPlan) : Collections.emptyList();
+
             idSemestre = datos.getIdSemestre();
-            bloques = obtenerBloques(idSemestre);
+            bloques = idSemestre != null ? obtenerBloques(idSemestre) : Collections.emptyList();
+
             idBloque = datos.getIdBloque();
-            programas = convertirANodosSelectItem(nuevaBajaService.obtenerProgramasPorEje(idBloque != null ? idBloque : idSemestre));
-            idPrograma = datos.getIdPrograma();
-            idPeriodo = datos.getPeriodo();
-            eventos = idPeriodo != null && idPrograma != null
-                    ? convertirANodosSelectItem(nuevaBajaService.obtenerEventosPorPeriodoYPrograma(idPeriodo, idPrograma))
+            Long idEjeCapacitacion = idBloque != null ? idBloque : idSemestre;
+            programas = idEjeCapacitacion != null
+                    ? convertirANodosSelectItem(nuevaBajaService.obtenerProgramasPorEje(idEjeCapacitacion))
                     : Collections.emptyList();
-            idEvento = datos.getIdEvento();
+            idPrograma = datos.getIdPrograma();
+
+            if (idPeriodo == null) {
+                idPeriodo = datos.getPeriodo();
+            }
+
+            if (idPeriodo != null && idPrograma != null) {
+                eventos = convertirANodosSelectItem(
+                        nuevaBajaService.obtenerEventosPorPeriodoYPrograma(idPeriodo, idPrograma));
+            } else if (eventos == null) {
+                eventos = Collections.emptyList();
+            }
+
+            if (idEvento == null) {
+                idEvento = datos.getIdEvento();
+            }
             actualizarVisibilidadCampos();
         } catch (Exception ex) {
             LOGGER.error("Error al consultar datos por matrícula", ex);


### PR DESCRIPTION
## Summary
- Obtains the user plan from `tbl_persona_aspirante` and filters malla curricular by the real plan-semester-block hierarchy
- Allows matricula lookup to return partial data while keeping configured event/period values intact
- Updates the baja form bean to populate plan, semestres, bloques y eventos únicamente con la estructura correcta

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d06a76424832fa0f6d1165008038a)