### PR TITLE
Show loading feedback and matricula not found notice

### DIFF
--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -31,7 +31,9 @@
                                         <p:ajax event="blur"
                                                 process="@this"
                                                 listener="#{nuevaBajaUsuarioBean.onMatriculaChange}"
-                                                update="camposBaja msgsNuevaBaja" />
+                                                update="camposBaja msgsNuevaBaja"
+                                                onstart="PF('dialogLayout').show()"
+                                                oncomplete="PF('dialogLayout').hide()" />
                                     </p:inputText>
                                     <p:message for="matricula" display="text" />
                                 </div>
@@ -267,6 +269,26 @@
                         <div class="col-md-12 text-right">
                             <p:commandButton value="Cerrar" styleClass="btn btn-default"
                                              onclick="PF('dlgNuevaBajaError').hide()" />
+                        </div>
+                    </div>
+                </p:dialog>
+
+                <p:dialog appendTo="@(body)" draggable="false" position="center"
+                          resizable="false" closable="false" modal="true" width="600px"
+                          widgetVar="dlgMatriculaNoRegistrada" header="Informativo" dynamic="true">
+                    <div class="form-group">
+                        <div class="row">
+                            <div class="col-md-12">
+                                <h:outputText styleClass="bloque"
+                                              value="#{nuevaBajaUsuarioBean.mensajeMatriculaNoRegistrada}" />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-12 text-right">
+                            <p:commandButton value="Cerrar" styleClass="btn btn-default"
+                                             onclick="PF('dlgMatriculaNoRegistrada').hide()" />
                         </div>
                     </div>
                 </p:dialog>

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
@@ -56,6 +56,7 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
     private boolean mostrarEvento;
     private String mensajeErrorDialogo;
     private String mensajeExitoDialogo;
+    private String mensajeMatriculaNoRegistrada;
     private boolean esTipoDefinitiva;
     private boolean esTipoTemporalOParcial;
     private boolean esSinAsignaturas;
@@ -72,6 +73,7 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
         mostrarPrograma = true;
         mostrarPeriodo = true;
         mostrarEvento = true;
+        mensajeMatriculaNoRegistrada = null;
         limpiarFormulario();
     }
 
@@ -96,7 +98,8 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
             BajaMatriculaDetalleDTO datos = nuevaBajaService.obtenerDatosPorMatricula(matriculaUsuario.trim());
 
             if (datos == null) {
-                agregarMsgWarn("La matrícula no tiene datos válidos", null);
+                mensajeMatriculaNoRegistrada = "La matrícula no está registrada";
+                mostrarDialogo("dlgMatriculaNoRegistrada");
                 return;
             }
 
@@ -215,6 +218,7 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
         motivo = null;
         quienAplica = null;
         numeroSolicitud = null;
+        mensajeMatriculaNoRegistrada = null;
 
         esTipoDefinitiva = false;
         esTipoTemporalOParcial = false;
@@ -581,6 +585,14 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
 
     public void setMensajeExitoDialogo(String mensajeExitoDialogo) {
         this.mensajeExitoDialogo = mensajeExitoDialogo;
+    }
+
+    public String getMensajeMatriculaNoRegistrada() {
+        return mensajeMatriculaNoRegistrada;
+    }
+
+    public void setMensajeMatriculaNoRegistrada(String mensajeMatriculaNoRegistrada) {
+        this.mensajeMatriculaNoRegistrada = mensajeMatriculaNoRegistrada;
     }
 
     public boolean isMostrarSemestre() {


### PR DESCRIPTION
## Summary
- show the loading dialog when the matricula field loses focus and triggers the lookup
- display an informational modal when the entered matricula is not registered

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e2f6f7494832fa9b28f6c349926d1)