### PR TITLE
Controlar habilitación de listas en nueva baja

### DIFF
--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -60,6 +60,7 @@
                                     <p:selectOneMenu id="plan"
                                                      value="#{nuevaBajaUsuarioBean.idPlan}"
                                                      styleClass="col-xs-12"
+                                                     disabled="#{!nuevaBajaUsuarioBean.planHabilitado}"
                                                      required="true"
                                                      requiredMessage="Seleccione un plan">
                                         <f:selectItem itemLabel="Seleccionar" itemValue="#{null}" />
@@ -81,6 +82,7 @@
                                     <p:selectOneMenu id="semestre"
                                                      value="#{nuevaBajaUsuarioBean.idSemestre}"
                                                      styleClass="col-xs-12"
+                                                     disabled="#{!nuevaBajaUsuarioBean.semestreHabilitado}"
                                                      required="#{nuevaBajaUsuarioBean.semestreRequerido()}"
                                                      requiredMessage="Seleccione un semestre">
                                         <f:selectItem itemLabel="Seleccionar" itemValue="#{null}" />
@@ -98,6 +100,7 @@
                                     <p:selectOneMenu id="bloque"
                                                      value="#{nuevaBajaUsuarioBean.idBloque}"
                                                      styleClass="col-xs-12"
+                                                     disabled="#{!nuevaBajaUsuarioBean.bloqueHabilitado}"
                                                      required="#{nuevaBajaUsuarioBean.bloqueRequerido()}"
                                                      requiredMessage="Seleccione un bloque">
                                         <f:selectItem itemLabel="Seleccionar" itemValue="#{null}" />
@@ -115,6 +118,7 @@
                                         <p:selectOneMenu id="programa"
                                                          value="#{nuevaBajaUsuarioBean.idPrograma}"
                                                          styleClass="col-xs-12"
+                                                         disabled="#{!nuevaBajaUsuarioBean.programaHabilitado}"
                                                          required="#{nuevaBajaUsuarioBean.mostrarPrograma}"
                                                          requiredMessage="Seleccione un programa">
                                             <f:selectItem itemLabel="Seleccionar" itemValue="#{null}" />
@@ -132,6 +136,7 @@
                                         <p:selectOneMenu id="periodo"
                                                          value="#{nuevaBajaUsuarioBean.idPeriodo}"
                                                          styleClass="col-xs-12"
+                                                         disabled="#{!nuevaBajaUsuarioBean.periodoHabilitado}"
                                                          required="#{nuevaBajaUsuarioBean.mostrarPeriodo}"
                                                          requiredMessage="Seleccione un periodo">
                                             <f:selectItem itemLabel="Seleccionar" itemValue="#{null}" />
@@ -152,7 +157,8 @@
                                     <p:outputLabel styleClass="bloque" for="evento" value="Evento:" />
                                     <p:selectOneMenu id="evento"
                                                      value="#{nuevaBajaUsuarioBean.idEvento}"
-                                                     styleClass="col-xs-12">
+                                                     styleClass="col-xs-12"
+                                                     disabled="#{!nuevaBajaUsuarioBean.eventoHabilitado}">
                                         <f:selectItem itemLabel="Seleccionar" itemValue="#{null}" />
                                         <f:selectItems value="#{nuevaBajaUsuarioBean.eventos}" />
                                     </p:selectOneMenu>

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
@@ -54,6 +54,13 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
     private boolean mostrarPrograma;
     private boolean mostrarPeriodo;
     private boolean mostrarEvento;
+    private boolean planHabilitado;
+    private boolean semestreHabilitado;
+    private boolean bloqueHabilitado;
+    private boolean programaHabilitado;
+    private boolean periodoHabilitado;
+    private boolean eventoHabilitado;
+    private boolean matriculaValida;
     private String mensajeErrorDialogo;
     private String mensajeExitoDialogo;
     private String mensajeMatriculaNoRegistrada;
@@ -89,8 +96,10 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
 
     public void onMatriculaChange() {
         limpiarDatosDependientes();
+        deshabilitarListas();
 
         if (matriculaUsuario == null || matriculaUsuario.trim().isEmpty()) {
+            actualizarHabilitacionSecuencial();
             return;
         }
 
@@ -100,9 +109,11 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
             if (datos == null) {
                 mensajeMatriculaNoRegistrada = "La matrícula no está registrada";
                 mostrarDialogo("dlgMatriculaNoRegistrada");
+                actualizarHabilitacionSecuencial();
                 return;
             }
 
+            matriculaValida = true;
             idPlan = datos.getIdPlan();
             semestres = idPlan != null ? obtenerSemestres(idPlan) : Collections.emptyList();
 
@@ -134,25 +145,31 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
         } catch (Exception ex) {
             LOGGER.error("Error al consultar datos por matrícula", ex);
             agregarMsgError("La matrícula no tiene datos válidos", null);
+            deshabilitarListas();
         }
+        actualizarHabilitacionSecuencial();
     }
 
     public void onSemestreChange() {
         bloques = idSemestre != null ? obtenerBloques(idSemestre) : Collections.emptyList();
         idBloque = null;
         actualizarProgramas();
+        actualizarHabilitacionSecuencial();
     }
 
     public void onBloqueChange() {
         actualizarProgramas();
+        actualizarHabilitacionSecuencial();
     }
 
     public void onPeriodoChange() {
         actualizarEventos();
+        actualizarHabilitacionSecuencial();
     }
 
     public void onProgramaChange() {
         actualizarEventos();
+        actualizarHabilitacionSecuencial();
     }
 
     public void registrarBaja() {
@@ -228,6 +245,7 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
         mostrarPrograma = true;
         mostrarPeriodo = true;
         mostrarEvento = true;
+        deshabilitarListas();
     }
 
     private void limpiarDatosDependientes() {
@@ -280,6 +298,27 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
             eventos = Collections.emptyList();
         }
         idEvento = null;
+        actualizarHabilitacionSecuencial();
+    }
+
+    private void deshabilitarListas() {
+        matriculaValida = false;
+        planHabilitado = false;
+        semestreHabilitado = false;
+        bloqueHabilitado = false;
+        programaHabilitado = false;
+        periodoHabilitado = false;
+        eventoHabilitado = false;
+    }
+
+    private void actualizarHabilitacionSecuencial() {
+        planHabilitado = matriculaValida;
+        semestreHabilitado = planHabilitado && mostrarSemestre && idPlan != null;
+        bloqueHabilitado = semestreHabilitado && mostrarBloque && idSemestre != null;
+        programaHabilitado = mostrarPrograma && (bloqueHabilitado || (semestreHabilitado && !mostrarBloque))
+                && (idSemestre != null || idBloque != null);
+        periodoHabilitado = mostrarPeriodo && programaHabilitado && idPrograma != null;
+        eventoHabilitado = mostrarEvento && periodoHabilitado && idPeriodo != null && !idPeriodo.trim().isEmpty();
     }
 
     private void actualizarVisibilidadCampos() {
@@ -290,6 +329,7 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
             esTipoDefinitiva = false;
             esTipoTemporalOParcial = false;
             esSinAsignaturas = false;
+            actualizarHabilitacionSecuencial();
             return;
         }
 
@@ -321,6 +361,7 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
                 semestres = obtenerSemestres(idPlan);
             }
         }
+        actualizarHabilitacionSecuencial();
     }
 
     private void prepararValoresParaBajaDefinitiva() {
@@ -633,6 +674,54 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
 
     public void setMostrarEvento(boolean mostrarEvento) {
         this.mostrarEvento = mostrarEvento;
+    }
+
+    public boolean isPlanHabilitado() {
+        return planHabilitado;
+    }
+
+    public void setPlanHabilitado(boolean planHabilitado) {
+        this.planHabilitado = planHabilitado;
+    }
+
+    public boolean isSemestreHabilitado() {
+        return semestreHabilitado;
+    }
+
+    public void setSemestreHabilitado(boolean semestreHabilitado) {
+        this.semestreHabilitado = semestreHabilitado;
+    }
+
+    public boolean isBloqueHabilitado() {
+        return bloqueHabilitado;
+    }
+
+    public void setBloqueHabilitado(boolean bloqueHabilitado) {
+        this.bloqueHabilitado = bloqueHabilitado;
+    }
+
+    public boolean isProgramaHabilitado() {
+        return programaHabilitado;
+    }
+
+    public void setProgramaHabilitado(boolean programaHabilitado) {
+        this.programaHabilitado = programaHabilitado;
+    }
+
+    public boolean isPeriodoHabilitado() {
+        return periodoHabilitado;
+    }
+
+    public void setPeriodoHabilitado(boolean periodoHabilitado) {
+        this.periodoHabilitado = periodoHabilitado;
+    }
+
+    public boolean isEventoHabilitado() {
+        return eventoHabilitado;
+    }
+
+    public void setEventoHabilitado(boolean eventoHabilitado) {
+        this.eventoHabilitado = eventoHabilitado;
     }
 
     public NuevaBajaService getNuevaBajaService() {


### PR DESCRIPTION
## Summary
- Deshabilitar las listas de nueva baja hasta que se valide la matrícula y activar cada nivel de manera jerárquica
- Incorporar lógica en el bean para controlar habilitación y limpieza ante matrículas vacías o inválidas
- Actualizar la vista para reflejar el nuevo estado bloqueado de planes, semestres, bloques, programas, periodos y eventos

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e4398e15c832fb25a99eecc81b30a)