### PR TITLE
Update consulta de bajas queries and UI

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/ConsultaBajaDTO.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/ConsultaBajaDTO.java
@@ -1,0 +1,86 @@
+package mx.gob.sedesol.basegestor.commons.dto.gestionescolar;
+
+public class ConsultaBajaDTO {
+
+    private Long idBaja;
+    private String matricula;
+    private String plan;
+    private String programa;
+    private String evento;
+    private String tipoBaja;
+    private String estructura;
+    private String periodo;
+    private String estatus;
+
+    public Long getIdBaja() {
+        return idBaja;
+    }
+
+    public void setIdBaja(Long idBaja) {
+        this.idBaja = idBaja;
+    }
+
+    public String getMatricula() {
+        return matricula;
+    }
+
+    public void setMatricula(String matricula) {
+        this.matricula = matricula;
+    }
+
+    public String getPlan() {
+        return plan;
+    }
+
+    public void setPlan(String plan) {
+        this.plan = plan;
+    }
+
+    public String getPrograma() {
+        return programa;
+    }
+
+    public void setPrograma(String programa) {
+        this.programa = programa;
+    }
+
+    public String getEvento() {
+        return evento;
+    }
+
+    public void setEvento(String evento) {
+        this.evento = evento;
+    }
+
+    public String getTipoBaja() {
+        return tipoBaja;
+    }
+
+    public void setTipoBaja(String tipoBaja) {
+        this.tipoBaja = tipoBaja;
+    }
+
+    public String getEstructura() {
+        return estructura;
+    }
+
+    public void setEstructura(String estructura) {
+        this.estructura = estructura;
+    }
+
+    public String getPeriodo() {
+        return periodo;
+    }
+
+    public void setPeriodo(String periodo) {
+        this.periodo = periodo;
+    }
+
+    public String getEstatus() {
+        return estatus;
+    }
+
+    public void setEstatus(String estatus) {
+        this.estatus = estatus;
+    }
+}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/ConsultaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/ConsultaBajaRepository.java
@@ -1,0 +1,80 @@
+package mx.gob.sedesol.basegestor.model.repositories.gestionescolar;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
+import mx.gob.sedesol.basegestor.commons.utils.ObjectUtils;
+
+@Repository
+public class ConsultaBajaRepository implements IConsultaBajaRepository {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Override
+    public List<ConsultaBajaDTO> buscarBajas(String matricula, String nombrePeriodo, Integer estatus) {
+
+        String consulta = "SELECT rpb.id_baja, "
+                + " tp.sso_idUsuario AS matricula, "
+                + " tpl.nombre AS plan, "
+                + " tfdp.nombre_tentativo AS programa, "
+                + " te.nombre_ec AS evento, "
+                + " ctb.nombre AS tipo_baja, "
+                + " CONCAT((SELECT tmc2.nombre FROM tbl_malla_curricular tmc2 WHERE tmc2.id = tmc.id_padre), ' ', tmc.nombre) AS estructura, "
+                + " tpi.nombre_periodo AS periodo, "
+                + " IF(rpb.contabilizar, 'Aplicada', 'Pendiente') AS estatus "
+                + "FROM rel_persona_bajas rpb "
+                + " JOIN tbl_persona tp ON tp.id_persona = rpb.id_persona "
+                + " JOIN tbl_planes tpl ON tpl.id_plan = rpb.id_plan "
+                + " JOIN tbl_ficha_descriptiva_programa tfdp ON tfdp.id_programa = rpb.id_programa "
+                + " JOIN rel_motivo_baja rmb ON rmb.id_motivo_baja = rpb.motivo_baja_id "
+                + " JOIN cat_tipo_bajas ctb ON ctb.id_tipo_baja = rmb.tipo_baja_id "
+                + " JOIN tbl_malla_curricular tmc ON tmc.id = tfdp.id_eje_capacitacion "
+                + " LEFT JOIN tbl_eventos te ON te.id_evento = rpb.id_evento "
+                + " LEFT JOIN tbl_periodos_inscripcion tpi ON te.cve_evento_cap LIKE CONCAT('%', tpi.nombre_periodo, '%') "
+                + "WHERE rpb.contabilizar = :estatusSeleccionado "
+                + " AND tp.sso_idUsuario = :matriculaProporcionada "
+                + " AND tpi.nombre_periodo = :nombrePeriodoProporcionado";
+
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("estatusSeleccionado", estatus);
+        query.setParameter("matriculaProporcionada", matricula);
+        query.setParameter("nombrePeriodoProporcionado", nombrePeriodo);
+
+        List<Object[]> resultados = query.getResultList();
+        List<ConsultaBajaDTO> bajas = new ArrayList<>();
+
+        if (!ObjectUtils.isNullOrEmpty(resultados)) {
+            for (Object[] registro : resultados) {
+                ConsultaBajaDTO dto = new ConsultaBajaDTO();
+                dto.setIdBaja(registro[0] != null ? Long.valueOf(registro[0].toString()) : null);
+                dto.setMatricula(registro[1] != null ? registro[1].toString() : "");
+                dto.setPlan(registro[2] != null ? registro[2].toString() : "");
+                dto.setPrograma(registro[3] != null ? registro[3].toString() : "");
+                dto.setEvento(registro[4] != null ? registro[4].toString() : "");
+                dto.setTipoBaja(registro[5] != null ? registro[5].toString() : "");
+                dto.setEstructura(registro[6] != null ? registro[6].toString() : "");
+                dto.setPeriodo(registro[7] != null ? registro[7].toString() : "");
+                dto.setEstatus(registro[8] != null ? registro[8].toString() : "");
+                bajas.add(dto);
+            }
+        }
+
+        return bajas;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<String> obtenerPeriodosInscripcion() {
+        String consulta = "SELECT tpi.nombre_periodo FROM tbl_periodos_inscripcion tpi";
+        Query query = entityManager.createNativeQuery(consulta);
+        return query.getResultList();
+    }
+}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/IConsultaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/IConsultaBajaRepository.java
@@ -1,0 +1,12 @@
+package mx.gob.sedesol.basegestor.model.repositories.gestionescolar;
+
+import java.util.List;
+
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
+
+public interface IConsultaBajaRepository {
+
+    List<ConsultaBajaDTO> buscarBajas(String matricula, String nombrePeriodo, Integer estatus);
+
+    List<String> obtenerPeriodosInscripcion();
+}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/ConsultaBajaService.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/ConsultaBajaService.java
@@ -1,0 +1,12 @@
+package mx.gob.sedesol.basegestor.service.gestionescolar;
+
+import java.util.List;
+
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
+
+public interface ConsultaBajaService {
+
+    List<ConsultaBajaDTO> buscarBajas(String matricula, String nombrePeriodo, Integer estatus);
+
+    List<String> obtenerPeriodosInscripcion();
+}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/ConsultaBajaServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/ConsultaBajaServiceImpl.java
@@ -1,0 +1,41 @@
+package mx.gob.sedesol.basegestor.service.impl.gestionescolar;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
+import mx.gob.sedesol.basegestor.model.repositories.gestionescolar.IConsultaBajaRepository;
+import mx.gob.sedesol.basegestor.service.gestionescolar.ConsultaBajaService;
+
+@Service("consultaBajaService")
+public class ConsultaBajaServiceImpl implements ConsultaBajaService {
+
+    private static final Logger LOGGER = Logger.getLogger(ConsultaBajaServiceImpl.class);
+
+    @Autowired
+    private IConsultaBajaRepository consultaBajaRepository;
+
+    @Override
+    public List<ConsultaBajaDTO> buscarBajas(String matricula, String nombrePeriodo, Integer estatus) {
+        try {
+            return consultaBajaRepository.buscarBajas(matricula, nombrePeriodo, estatus);
+        } catch (Exception ex) {
+            LOGGER.error("Error al consultar bajas de usuarios", ex);
+            return new ArrayList<>();
+        }
+    }
+
+    @Override
+    public List<String> obtenerPeriodosInscripcion() {
+        try {
+            return consultaBajaRepository.obtenerPeriodosInscripcion();
+        } catch (Exception ex) {
+            LOGGER.error("Error al consultar los periodos de inscripción", ex);
+            return new ArrayList<>();
+        }
+    }
+}

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -17,17 +17,151 @@
 
                 <p:panel header="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.accion.consultarBaja')}"
                          styleClass="panel-primary">
-                    <div class="row">
-                        <div class="col-md-12">
-                            <h:outputText value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.mensaje.pendiente')}" />
+                    <div class="form-group">
+                        <div class="row">
+                            <div class="col-md-4 col-xs-12">
+                                <p:outputLabel for="matricula"
+                                               styleClass="bloque requerido"
+                                               value="Matrícula/Usuario:" />
+                                <p:inputText id="matricula"
+                                             value="#{consultaBajaUsuariosBean.matricula}"
+                                             styleClass="form-control"
+                                             required="true"
+                                             requiredMessage="La matrícula o usuario es obligatorio." />
+                                <p:message for="matricula" display="text" />
+                            </div>
+
+                            <div class="col-md-4 col-xs-12">
+                                <p:outputLabel for="periodo"
+                                               styleClass="bloque requerido"
+                                               value="Periodo:" />
+                                <p:selectOneMenu id="periodo"
+                                                 value="#{consultaBajaUsuariosBean.periodoSeleccionado}"
+                                                 styleClass="col-xs-12"
+                                                 required="true"
+                                                 requiredMessage="El periodo es obligatorio.">
+                                    <p:ajax event="change" process="@this" />
+                                    <f:selectItem itemLabel="#{sistema.obtenerTexto('gw.textos.menu.seleccionar')}" itemValue="#{null}" />
+                                    <f:selectItems value="#{consultaBajaUsuariosBean.periodos}"
+                                                   var="periodo"
+                                                   itemLabel="#{periodo}"
+                                                   itemValue="#{periodo}" />
+                                </p:selectOneMenu>
+                                <p:message for="periodo" display="text" />
+                            </div>
+
+                            <div class="col-md-4 col-xs-12">
+                                <p:outputLabel for="estatus"
+                                               styleClass="bloque requerido"
+                                               value="Estatus*" />
+                                <p:selectOneMenu id="estatus"
+                                                 value="#{consultaBajaUsuariosBean.estatusSeleccionado}"
+                                                 styleClass="col-xs-12"
+                                                 required="true"
+                                                 requiredMessage="El estatus es obligatorio.">
+                                    <p:ajax event="change" process="@this" />
+                                    <f:selectItem itemLabel="#{sistema.obtenerTexto('gw.textos.menu.seleccionar')}" itemValue="#{null}" />
+                                    <f:selectItem itemLabel="Aplicada" itemValue="1" />
+                                    <f:selectItem itemLabel="Pendiente" itemValue="0" />
+                                </p:selectOneMenu>
+                                <p:message for="estatus" display="text" />
+                            </div>
                         </div>
                     </div>
-                    <div class="row" style="margin-top: 15px;">
-                        <div class="col-md-12 text-right">
-                            <p:commandButton value="#{sistema.obtenerTexto('gw.ge.texto.regresar')}"
-                                             action="#{altasBajasUsuariosBean.regresarAlModulo}"
-                                             styleClass="btn btn-default"
-                                             ajax="false" />
+
+                    <div class="form-group">
+                        <div class="row">
+                            <div class="col-md-12 text-right">
+                                <p:commandButton value="#{sistema.obtenerTexto('gw.ge.texto.regresar')}"
+                                                 action="#{altasBajasUsuariosBean.regresarAlModulo}"
+                                                 styleClass="btn btn-default"
+                                                 ajax="false" />
+
+                                <p:commandButton value="Limpiar campos"
+                                                 actionListener="#{consultaBajaUsuariosBean.limpiar}"
+                                                 process="@this"
+                                                 update="@form"
+                                                 styleClass="btn btn-default" />
+
+                                <p:commandButton id="btnBuscarBajas"
+                                                 process="@form"
+                                                 ajax="true"
+                                                 update="@form"
+                                                 styleClass="btn btn-primary pull-right"
+                                                 actionListener="#{consultaBajaUsuariosBean.buscar}"
+                                                 value="#{sistema.obtenerTexto('gw.ga.btn.buscar')}" />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-12">
+                            <p:dataTable id="tablaBajas"
+                                         value="#{consultaBajaUsuariosBean.resultados}"
+                                         var="baja"
+                                         paginator="true"
+                                         rows="10"
+                                         paginatorPosition="bottom"
+                                         emptyMessage="No se encontraron registros"
+                                         tableStyleClass="table"
+                                         reflow="true">
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Matrícula" />
+                                    </f:facet>
+                                    <h:outputText value="#{baja.matricula}" />
+                                </p:column>
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Plan" />
+                                    </f:facet>
+                                    <h:outputText value="#{baja.plan}" />
+                                </p:column>
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Programa" />
+                                    </f:facet>
+                                    <h:outputText value="#{baja.programa}" />
+                                </p:column>
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Evento" />
+                                    </f:facet>
+                                    <h:outputText value="#{baja.evento}" />
+                                </p:column>
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Tipo de baja" />
+                                    </f:facet>
+                                    <h:outputText value="#{baja.tipoBaja}" />
+                                </p:column>
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Estructura" />
+                                    </f:facet>
+                                    <h:outputText value="#{baja.estructura}" />
+                                </p:column>
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Periodo" />
+                                    </f:facet>
+                                    <h:outputText value="#{baja.periodo}" />
+                                </p:column>
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Estatus" />
+                                    </f:facet>
+                                    <h:outputText value="#{baja.estatus}" />
+                                </p:column>
+                            </p:dataTable>
                         </div>
                     </div>
                 </p:panel>

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/ConsultaBajaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/ConsultaBajaUsuariosBean.java
@@ -1,0 +1,138 @@
+package mx.gob.sedesol.gestorweb.beans.gestionescolar;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ManagedProperty;
+import javax.faces.bean.ViewScoped;
+
+import org.apache.log4j.Logger;
+
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
+import mx.gob.sedesol.basegestor.commons.utils.ObjectUtils;
+import mx.gob.sedesol.basegestor.service.gestionescolar.ConsultaBajaService;
+import mx.gob.sedesol.gestorweb.beans.acceso.BaseBean;
+
+@ManagedBean
+@ViewScoped
+public class ConsultaBajaUsuariosBean extends BaseBean {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = Logger.getLogger(ConsultaBajaUsuariosBean.class);
+
+    @ManagedProperty(value = "#{consultaBajaService}")
+    private transient ConsultaBajaService consultaBajaService;
+
+    private String matricula;
+    private String periodoSeleccionado;
+    private Integer estatusSeleccionado;
+    private List<String> periodos;
+    private List<ConsultaBajaDTO> resultados;
+
+    @PostConstruct
+    public void init() {
+        LOGGER.info("Inicializando consulta de bajas de usuarios");
+        resultados = new ArrayList<>();
+        cargarPeriodos();
+    }
+
+    private void cargarPeriodos() {
+        periodos = consultaBajaService.obtenerPeriodosInscripcion();
+        if (periodos == null) {
+            periodos = new ArrayList<>();
+        }
+    }
+
+    public void buscar() {
+        if (!validarCampos()) {
+            return;
+        }
+
+        resultados = consultaBajaService.buscarBajas(matricula.trim(), periodoSeleccionado, estatusSeleccionado);
+
+        if (ObjectUtils.isNullOrEmpty(resultados)) {
+            agregarMsgInfo("No se encontraron registros", null);
+        }
+    }
+
+    public void limpiar() {
+        matricula = null;
+        periodoSeleccionado = null;
+        estatusSeleccionado = null;
+        resultados = new ArrayList<>();
+    }
+
+    private boolean validarCampos() {
+        boolean valido = true;
+
+        if (ObjectUtils.isNullOrEmpty(matricula) || matricula.trim().isEmpty()) {
+            agregarMsgError("La matrícula o usuario es obligatorio.", null);
+            valido = false;
+        } else {
+            matricula = matricula.trim();
+        }
+
+        if (ObjectUtils.isNullOrEmpty(periodoSeleccionado)) {
+            agregarMsgError("El periodo es obligatorio.", null);
+            valido = false;
+        }
+
+        if (ObjectUtils.isNullOrEmpty(estatusSeleccionado)) {
+            agregarMsgError("El estatus es obligatorio.", null);
+            valido = false;
+        }
+
+        return valido;
+    }
+
+    public String getMatricula() {
+        return matricula;
+    }
+
+    public void setMatricula(String matricula) {
+        this.matricula = matricula;
+    }
+
+    public String getPeriodoSeleccionado() {
+        return periodoSeleccionado;
+    }
+
+    public void setPeriodoSeleccionado(String periodoSeleccionado) {
+        this.periodoSeleccionado = periodoSeleccionado;
+    }
+
+    public Integer getEstatusSeleccionado() {
+        return estatusSeleccionado;
+    }
+
+    public void setEstatusSeleccionado(Integer estatusSeleccionado) {
+        this.estatusSeleccionado = estatusSeleccionado;
+    }
+
+    public List<String> getPeriodos() {
+        return periodos;
+    }
+
+    public void setPeriodos(List<String> periodos) {
+        this.periodos = periodos;
+    }
+
+    public List<ConsultaBajaDTO> getResultados() {
+        return resultados;
+    }
+
+    public void setResultados(List<ConsultaBajaDTO> resultados) {
+        this.resultados = resultados;
+    }
+
+    public ConsultaBajaService getConsultaBajaService() {
+        return consultaBajaService;
+    }
+
+    public void setConsultaBajaService(ConsultaBajaService consultaBajaService) {
+        this.consultaBajaService = consultaBajaService;
+    }
+}


### PR DESCRIPTION
## Summary
- adjust bajas repository query to match required matricula, periodo y estatus filters and return labeled status values
- expose periodos de inscripción and updated search parameters through the service layer and managed bean
- update consulta de bajas UI bindings to use the new period list and display returned status text

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924f85732dc832fb656187a28e4f244)