### PR TITLE
Limpiar formulario al borrar matrícula

### DIFF
--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
@@ -96,6 +96,7 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
 
     public void onMatriculaChange() {
         limpiarDatosDependientes();
+        limpiarListasDesplegables();
         deshabilitarListas();
 
         if (matriculaUsuario == null || matriculaUsuario.trim().isEmpty()) {
@@ -104,6 +105,7 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
         }
 
         try {
+            recargarListasBase();
             BajaMatriculaDetalleDTO datos = nuevaBajaService.obtenerDatosPorMatricula(matriculaUsuario.trim());
 
             if (datos == null) {
@@ -270,6 +272,15 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
         eventos = Collections.emptyList();
     }
 
+    private void recargarListasBase() {
+        if (planes == null || planes.isEmpty()) {
+            planes = convertirAPlanesSelectItem(nuevaBajaService.obtenerPlanes());
+        }
+        if (periodos == null || periodos.isEmpty()) {
+            periodos = convertirAPeriodosSelectItem(nuevaBajaService.obtenerPeriodos());
+        }
+    }
+
     private void actualizarProgramas() {
         Long idEjeCapacitacion = idBloque != null ? idBloque : idSemestre;
         if (idEjeCapacitacion != null) {
@@ -373,6 +384,15 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
         semestres = Collections.emptyList();
         bloques = Collections.emptyList();
         programas = Collections.emptyList();
+        eventos = Collections.emptyList();
+    }
+
+    private void limpiarListasDesplegables() {
+        planes = Collections.emptyList();
+        semestres = Collections.emptyList();
+        bloques = Collections.emptyList();
+        programas = Collections.emptyList();
+        periodos = Collections.emptyList();
         eventos = Collections.emptyList();
     }
 

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
@@ -95,14 +95,15 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
     }
 
     public void onMatriculaChange() {
+        if (matriculaUsuario == null || matriculaUsuario.trim().isEmpty()) {
+            limpiarFormulario();
+            limpiarListasDesplegables();
+            return;
+        }
+
         limpiarDatosDependientes();
         limpiarListasDesplegables();
         deshabilitarListas();
-
-        if (matriculaUsuario == null || matriculaUsuario.trim().isEmpty()) {
-            actualizarHabilitacionSecuencial();
-            return;
-        }
 
         try {
             recargarListasBase();


### PR DESCRIPTION
## Summary
- limpiar todas las listas y deshabilitar combos al borrar el contenido de la matrícula en la pantalla de Nueva baja
- recargar catálogos base cuando se introduce nuevamente una matrícula válida

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e89bb73dc832fa95eaebb4ea99bef)