### PR TITLE
Habilitar validación visual en Nueva Baja

### DIFF
--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -202,9 +202,9 @@
                                                  styleClass="btn btn-default" />
 
                                 <p:commandButton value="Agregar"
-                                                 actionListener="#{nuevaBajaUsuarioBean.registrarBaja}"
+                                                 action="#{nuevaBajaUsuarioBean.registrarBaja}"
                                                  process="@form"
-                                                 update="@form"
+                                                 update="camposBaja msgsNuevaBaja"
                                                  onstart="PF('dialogLayout').show()"
                                                  oncomplete="PF('dialogLayout').hide()"
                                                  styleClass="btn btn-primary pull-right" />

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
@@ -173,40 +173,6 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
     }
 
     public void registrarBaja() {
-        List<String> errores = new ArrayList<>();
-
-        if (matriculaUsuario == null || matriculaUsuario.trim().isEmpty()) {
-            errores.add("La matrícula o usuario es obligatoria");
-        }
-        if (idTipoBaja == null) {
-            errores.add("Seleccione un tipo de baja");
-        }
-        if (idPlan == null) {
-            errores.add("Seleccione un plan");
-        }
-
-        if (semestreRequerido() && idSemestre == null) {
-            errores.add("Seleccione un semestre");
-        }
-
-        if (mostrarPrograma && idPrograma == null) {
-            errores.add("Seleccione un programa");
-        }
-
-        if (mostrarBloque && esTipoTemporalOParcial && idBloque == null) {
-            errores.add("Seleccione un bloque");
-        }
-
-        if (mostrarPeriodo && (idPeriodo == null || idPeriodo.trim().isEmpty())) {
-            errores.add("Seleccione un periodo");
-        }
-
-        if (!errores.isEmpty()) {
-            mensajeErrorDialogo = "Ingrese los datos marcados como obligatorios.";
-            mostrarDialogo("dlgNuevaBajaValidacion");
-            return;
-        }
-
         try {
             BajaSolicitudDTO solicitud = construirSolicitud();
             nuevaBajaService.aplicarBaja(solicitud);


### PR DESCRIPTION
## Summary
- quitar validación manual en `NuevaBajaUsuarioBean` para permitir que los campos requeridos se validen como en Convocatorias
- mantener el flujo de éxito y error usando los diálogos existentes

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f192b99dc832f950242a1c198ddb1)