### PR TITLE
Habilita búsqueda de bajas por periodo de inscripción

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/ConsultaBajaDTO.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/ConsultaBajaDTO.java
@@ -2,6 +2,7 @@ package mx.gob.sedesol.basegestor.commons.dto.gestionescolar;
 
 public class ConsultaBajaDTO {
 
+    private Integer idBaja;
     private String matricula;
     private String plan;
     private String programa;
@@ -17,6 +18,14 @@ public class ConsultaBajaDTO {
 
     public void setMatricula(String matricula) {
         this.matricula = matricula;
+    }
+
+    public Integer getIdBaja() {
+        return idBaja;
+    }
+
+    public void setIdBaja(Integer idBaja) {
+        this.idBaja = idBaja;
     }
 
     public String getPlan() {

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/ConsultaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/ConsultaBajaRepository.java
@@ -9,6 +9,7 @@ import javax.persistence.Query;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
+import mx.gob.sedesol.basegestor.commons.dto.admin.CatalogoComunDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
 import mx.gob.sedesol.basegestor.commons.utils.ObjectUtils;
 
@@ -19,33 +20,34 @@ public class ConsultaBajaRepository implements IConsultaBajaRepository {
     private EntityManager entityManager;
 
     @Override
-    public List<ConsultaBajaDTO> buscarBajas(String matricula, Integer idPeriodo, Integer estatus) {
+    public List<ConsultaBajaDTO> buscarBajas(String matricula, String periodo, Integer estatus) {
 
-        String consulta = "SELECT p.sso_idUsuario AS matricula, "
-                + " pl.nombre AS plan, "
-                + " fdp.nombre_tentativo AS programa, "
-                + " e.nombre_ec AS evento, "
+        String consulta = "SELECT rpb.id_baja AS id_baja, "
+                + " tp.sso_idUsuario AS matricula, "
+                + " tpl.nombre AS plan, "
+                + " tfdp.nombre_tentativo AS programa, "
+                + " te.nombre_ec AS evento, "
                 + " ctb.nombre AS tipo_baja, "
-                + " rmp.nombre_estructuras AS estructura, "
-                + " cp.nombre AS periodo, "
+                + " CONCAT((SELECT tmc2.nombre FROM tbl_malla_curricular tmc2 WHERE tmc2.id = tmc.id_padre),' ', tmc.nombre) AS estructura, "
+                + " tpi.nombre_periodo AS periodo, "
                 + " rpb.contabilizar AS estatus "
                 + "FROM rel_persona_bajas rpb "
-                + " INNER JOIN tbl_persona p ON p.id_persona = rpb.id_persona "
-                + " INNER JOIN tbl_planes pl ON pl.id_plan = rpb.id_plan "
-                + " INNER JOIN tbl_ficha_descriptiva_programa fdp ON fdp.id_programa = rpb.id_programa "
-                + " INNER JOIN tbl_eventos e ON e.id_evento = rpb.id_evento "
-                + " INNER JOIN rel_motivo_baja rmb ON rmb.id_motivo_baja = rpb.motivo_baja_id "
-                + " INNER JOIN cat_tipo_bajas ctb ON ctb.id_tipo_baja = rmb.tipo_baja_id "
-                + " LEFT JOIN rel_malla_plan rmp ON rmp.id_plan = pl.id_plan "
-                + " LEFT JOIN cat_periodos cp ON cp.id_periodo = pl.id_periodo "
-                + "WHERE p.sso_idUsuario LIKE :matricula "
-                + " AND pl.id_periodo = :idPeriodo "
-                + " AND rpb.contabilizar = :estatus";
+                + " JOIN tbl_persona tp ON tp.id_persona = rpb.id_persona "
+                + " JOIN tbl_planes tpl ON tpl.id_plan = rpb.id_plan "
+                + " JOIN tbl_ficha_descriptiva_programa tfdp ON tfdp.id_programa = rpb.id_programa "
+                + " JOIN rel_motivo_baja rmb ON rmb.id_motivo_baja = rpb.motivo_baja_id "
+                + " JOIN cat_tipo_bajas ctb ON ctb.id_tipo_baja = rmb.tipo_baja_id "
+                + " JOIN tbl_malla_curricular tmc ON tmc.id = tfdp.id_eje_capacitacion "
+                + " LEFT JOIN tbl_eventos te ON te.id_evento = rpb.id_evento "
+                + " LEFT JOIN tbl_periodos_inscripcion tpi ON te.cve_evento_cap LIKE CONCAT('%', tpi.nombre_periodo, '%') "
+                + "WHERE rpb.contabilizar = :estatusSeleccionado "
+                + " AND tp.sso_idUsuario = :matriculaSeleccionada "
+                + " AND tpi.nombre_periodo = :periodoSeleccionado";
 
         Query query = entityManager.createNativeQuery(consulta);
-        query.setParameter("matricula", '%' + matricula + '%');
-        query.setParameter("idPeriodo", idPeriodo);
-        query.setParameter("estatus", estatus);
+        query.setParameter("matriculaSeleccionada", matricula);
+        query.setParameter("periodoSeleccionado", periodo);
+        query.setParameter("estatusSeleccionado", estatus);
 
         List<Object[]> resultados = query.getResultList();
         List<ConsultaBajaDTO> bajas = new ArrayList<>();
@@ -53,18 +55,39 @@ public class ConsultaBajaRepository implements IConsultaBajaRepository {
         if (!ObjectUtils.isNullOrEmpty(resultados)) {
             for (Object[] registro : resultados) {
                 ConsultaBajaDTO dto = new ConsultaBajaDTO();
-                dto.setMatricula(registro[0] != null ? registro[0].toString() : "");
-                dto.setPlan(registro[1] != null ? registro[1].toString() : "");
-                dto.setPrograma(registro[2] != null ? registro[2].toString() : "");
-                dto.setEvento(registro[3] != null ? registro[3].toString() : "");
-                dto.setTipoBaja(registro[4] != null ? registro[4].toString() : "");
-                dto.setEstructura(registro[5] != null ? registro[5].toString() : "");
-                dto.setPeriodo(registro[6] != null ? registro[6].toString() : "");
-                dto.setEstatus(registro[7] != null ? Integer.valueOf(registro[7].toString()) : null);
+                dto.setIdBaja(registro[0] != null ? Integer.valueOf(registro[0].toString()) : null);
+                dto.setMatricula(registro[1] != null ? registro[1].toString() : "");
+                dto.setPlan(registro[2] != null ? registro[2].toString() : "");
+                dto.setPrograma(registro[3] != null ? registro[3].toString() : "");
+                dto.setEvento(registro[4] != null ? registro[4].toString() : "");
+                dto.setTipoBaja(registro[5] != null ? registro[5].toString() : "");
+                dto.setEstructura(registro[6] != null ? registro[6].toString() : "");
+                dto.setPeriodo(registro[7] != null ? registro[7].toString() : "");
+                dto.setEstatus(registro[8] != null ? Integer.valueOf(registro[8].toString()) : null);
                 bajas.add(dto);
             }
         }
 
         return bajas;
+    }
+
+    @Override
+    public List<CatalogoComunDTO> obtenerPeriodos() {
+        String consulta = "SELECT tpi.nombre_periodo FROM tbl_periodos_inscripcion tpi";
+
+        Query query = entityManager.createNativeQuery(consulta);
+        List<String> registros = query.getResultList();
+        List<CatalogoComunDTO> periodos = new ArrayList<>();
+
+        if (!ObjectUtils.isNullOrEmpty(registros)) {
+            for (int i = 0; i < registros.size(); i++) {
+                CatalogoComunDTO periodo = new CatalogoComunDTO();
+                periodo.setId(i + 1);
+                periodo.setNombre(registros.get(i));
+                periodos.add(periodo);
+            }
+        }
+
+        return periodos;
     }
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/IConsultaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/IConsultaBajaRepository.java
@@ -2,9 +2,12 @@ package mx.gob.sedesol.basegestor.model.repositories.gestionescolar;
 
 import java.util.List;
 
+import mx.gob.sedesol.basegestor.commons.dto.admin.CatalogoComunDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
 
 public interface IConsultaBajaRepository {
 
-    List<ConsultaBajaDTO> buscarBajas(String matricula, Integer idPeriodo, Integer estatus);
+    List<ConsultaBajaDTO> buscarBajas(String matricula, String periodo, Integer estatus);
+
+    List<CatalogoComunDTO> obtenerPeriodos();
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/ConsultaBajaService.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/ConsultaBajaService.java
@@ -2,9 +2,12 @@ package mx.gob.sedesol.basegestor.service.gestionescolar;
 
 import java.util.List;
 
+import mx.gob.sedesol.basegestor.commons.dto.admin.CatalogoComunDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
 
 public interface ConsultaBajaService {
 
-    List<ConsultaBajaDTO> buscarBajas(String matricula, Integer idPeriodo, Integer estatus);
+    List<ConsultaBajaDTO> buscarBajas(String matricula, String periodo, Integer estatus);
+
+    List<CatalogoComunDTO> obtenerPeriodos();
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/ConsultaBajaServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/ConsultaBajaServiceImpl.java
@@ -7,6 +7,7 @@ import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import mx.gob.sedesol.basegestor.commons.dto.admin.CatalogoComunDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
 import mx.gob.sedesol.basegestor.model.repositories.gestionescolar.IConsultaBajaRepository;
 import mx.gob.sedesol.basegestor.service.gestionescolar.ConsultaBajaService;
@@ -20,11 +21,21 @@ public class ConsultaBajaServiceImpl implements ConsultaBajaService {
     private IConsultaBajaRepository consultaBajaRepository;
 
     @Override
-    public List<ConsultaBajaDTO> buscarBajas(String matricula, Integer idPeriodo, Integer estatus) {
+    public List<ConsultaBajaDTO> buscarBajas(String matricula, String periodo, Integer estatus) {
         try {
-            return consultaBajaRepository.buscarBajas(matricula, idPeriodo, estatus);
+            return consultaBajaRepository.buscarBajas(matricula, periodo, estatus);
         } catch (Exception ex) {
             LOGGER.error("Error al consultar bajas de usuarios", ex);
+            return new ArrayList<>();
+        }
+    }
+
+    @Override
+    public List<CatalogoComunDTO> obtenerPeriodos() {
+        try {
+            return consultaBajaRepository.obtenerPeriodos();
+        } catch (Exception ex) {
+            LOGGER.error("Error al consultar periodos de inscripción", ex);
             return new ArrayList<>();
         }
     }

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -82,7 +82,7 @@
                                 <p:commandButton id="btnBuscarBajas"
                                                  process="@form"
                                                  ajax="true"
-                                                 update=":frmConsultaBaja :frmResultadosBaja:tablaBajas"
+                                                 update=":frmAltasBajas:frmConsultaBaja :frmResultadosBaja:tablaBajas"
                                                  styleClass="btn btn-primary pull-right"
                                                  actionListener="#{consultaBajaUsuariosBean.buscar}"
                                                  value="#{sistema.obtenerTexto('gw.ga.btn.buscar')}" />

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -104,13 +104,6 @@
 
                                 <p:column styleClass="text-center">
                                     <f:facet name="header">
-                                        <h:outputText value="ID Baja" />
-                                    </f:facet>
-                                    <h:outputText value="#{baja.idBaja}" />
-                                </p:column>
-
-                                <p:column styleClass="text-center">
-                                    <f:facet name="header">
                                         <h:outputText value="Matrícula" />
                                     </f:facet>
                                     <h:outputText value="#{baja.matricula}" />
@@ -163,6 +156,22 @@
                                         <h:outputText value="Estatus" />
                                     </f:facet>
                                     <h:outputText value="#{consultaBajaUsuariosBean.obtenerNombreEstatus(baja.estatus)}" />
+                                </p:column>
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="Acciones" />
+                                    </f:facet>
+
+                                    <p:commandButton type="button"
+                                                     icon="fa fa-pencil"
+                                                     styleClass="btn-icon btn btn-default"
+                                                     title="Editar" />
+
+                                    <p:commandButton type="button"
+                                                     icon="fa fa-trash"
+                                                     styleClass="btn-icon btn btn-default"
+                                                     title="Eliminar" />
                                 </p:column>
                             </p:dataTable>
                         </div>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -45,7 +45,7 @@
                                     <f:selectItems value="#{consultaBajaUsuariosBean.periodos}"
                                                    var="periodo"
                                                    itemLabel="#{periodo.nombre}"
-                                                   itemValue="#{periodo.id}" />
+                                                   itemValue="#{periodo.nombre}" />
                                 </p:selectOneMenu>
                                 <p:message for="periodo" display="text" />
                             </div>
@@ -101,6 +101,13 @@
                                          emptyMessage="No se encontraron registros"
                                          tableStyleClass="table"
                                          reflow="true">
+
+                                <p:column styleClass="text-center">
+                                    <f:facet name="header">
+                                        <h:outputText value="ID Baja" />
+                                    </f:facet>
+                                    <h:outputText value="#{baja.idBaja}" />
+                                </p:column>
 
                                 <p:column styleClass="text-center">
                                     <f:facet name="header">

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -82,14 +82,19 @@
                                 <p:commandButton id="btnBuscarBajas"
                                                  process="@form"
                                                  ajax="true"
-                                                 update="@form"
+                                                 update="frmConsultaBaja frmResultadosBaja:tablaBajas"
                                                  styleClass="btn btn-primary pull-right"
                                                  actionListener="#{consultaBajaUsuariosBean.buscar}"
                                                  value="#{sistema.obtenerTexto('gw.ga.btn.buscar')}" />
                             </div>
                         </div>
                     </div>
+                </p:panel>
+            </h:form>
 
+            <h:form id="frmResultadosBaja">
+                <p:panel header="Listado de bajas encontradas"
+                         styleClass="panel-primary">
                     <div class="row">
                         <div class="col-md-12">
                             <p:dataTable id="tablaBajas"

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -82,7 +82,7 @@
                                 <p:commandButton id="btnBuscarBajas"
                                                  process="@form"
                                                  ajax="true"
-                                                 update="frmConsultaBaja frmResultadosBaja:tablaBajas"
+                                                 update=":frmConsultaBaja :frmResultadosBaja:tablaBajas"
                                                  styleClass="btn btn-primary pull-right"
                                                  actionListener="#{consultaBajaUsuariosBean.buscar}"
                                                  value="#{sistema.obtenerTexto('gw.ga.btn.buscar')}" />

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -82,7 +82,7 @@
                                 <p:commandButton id="btnBuscarBajas"
                                                  process="@form"
                                                  ajax="true"
-                                                 update=":frmAltasBajas:frmConsultaBaja :frmResultadosBaja:tablaBajas"
+                                                 update=":frmAltasBajas:frmConsultaBaja :frmAltasBajas:frmResultadosBaja:tablaBajas"
                                                  styleClass="btn btn-primary pull-right"
                                                  actionListener="#{consultaBajaUsuariosBean.buscar}"
                                                  value="#{sistema.obtenerTexto('gw.ga.btn.buscar')}" />

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/ConsultaBajaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/ConsultaBajaUsuariosBean.java
@@ -15,7 +15,6 @@ import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
 import mx.gob.sedesol.basegestor.commons.utils.ObjectUtils;
 import mx.gob.sedesol.basegestor.service.gestionescolar.ConsultaBajaService;
 import mx.gob.sedesol.gestorweb.beans.acceso.BaseBean;
-import mx.gob.sedesol.gestorweb.commons.constantes.ConstantesGestorWeb;
 
 @ManagedBean
 @ViewScoped
@@ -29,7 +28,7 @@ public class ConsultaBajaUsuariosBean extends BaseBean {
     private transient ConsultaBajaService consultaBajaService;
 
     private String matricula;
-    private Integer periodoSeleccionado;
+    private String periodoSeleccionado;
     private Integer estatusSeleccionado;
     private List<CatalogoComunDTO> periodos;
     private List<ConsultaBajaDTO> resultados;
@@ -41,13 +40,8 @@ public class ConsultaBajaUsuariosBean extends BaseBean {
         cargarPeriodos();
     }
 
-    @SuppressWarnings("unchecked")
     private void cargarPeriodos() {
-        periodos = (List<CatalogoComunDTO>) getSession().getServletContext()
-                .getAttribute(ConstantesGestorWeb.CAT_PERIODOS);
-        if (periodos == null) {
-            periodos = new ArrayList<>();
-        }
+        periodos = consultaBajaService.obtenerPeriodos();
     }
 
     public void buscar() {
@@ -107,11 +101,11 @@ public class ConsultaBajaUsuariosBean extends BaseBean {
         this.matricula = matricula;
     }
 
-    public Integer getPeriodoSeleccionado() {
+    public String getPeriodoSeleccionado() {
         return periodoSeleccionado;
     }
 
-    public void setPeriodoSeleccionado(Integer periodoSeleccionado) {
+    public void setPeriodoSeleccionado(String periodoSeleccionado) {
         this.periodoSeleccionado = periodoSeleccionado;
     }
 


### PR DESCRIPTION
## Summary
- actualiza la consulta de bajas para usar el nombre de periodo de inscripción y recuperar el ID de baja
- expone los periodos desde el servicio y ajusta el bean de consulta para usar el nombre de periodo al filtrar
- muestra el ID de baja y utiliza la lista actualizada de periodos en la tabla y el buscador de la vista

## Testing
- No tests were run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f31d8f384832f9721ca05398813de)