### PR TITLE
Add loading and informative dialogs to consulta de bajas

### DIFF
--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -89,7 +89,7 @@
                                                  styleClass="btn btn-primary pull-right"
                                                  actionListener="#{consultaBajaUsuariosBean.buscar}"
                                                  onstart="PF('dialogLayout').show()"
-                                                 oncomplete="PF('dialogLayout').hide(); if (args && args.sinResultados) {PF('dlgSinResultados').show();}"
+                                                  oncomplete="PF('dialogLayout').hide(); if (args &amp;&amp; args.sinResultados) {PF('dlgSinResultados').show();}"
                                                  value="#{sistema.obtenerTexto('gw.ga.btn.buscar')}" />
                             </div>
                         </div>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -10,6 +10,9 @@
     <ui:fragment rendered="#{menuGestorBean.rolTienePermiso('ALT_BAJ_USR_CON')}">
         <sec:authorize access="hasPermission(null, 'ALT_BAJ_USR_CON') ">
             <h:form id="frmConsultaBaja">
+                <p:ajaxStatus onstart="PF('dialogLayout').show()"
+                              onsuccess="PF('dialogLayout').hide()" />
+
                 <p:messages id="msgsConsultaBaja"
                              autoUpdate="true"
                              closable="true"
@@ -85,6 +88,8 @@
                                                  update=":frmAltasBajas:frmConsultaBaja :frmAltasBajas:frmResultadosBaja:tablaBajas"
                                                  styleClass="btn btn-primary pull-right"
                                                  actionListener="#{consultaBajaUsuariosBean.buscar}"
+                                                 onstart="PF('dialogLayout').show()"
+                                                 oncomplete="PF('dialogLayout').hide(); if (args && args.sinResultados) {PF('dlgSinResultados').show();}"
                                                  value="#{sistema.obtenerTexto('gw.ga.btn.buscar')}" />
                             </div>
                         </div>
@@ -183,6 +188,34 @@
                     </div>
                 </p:panel>
             </h:form>
+
+            <p:dialog appendTo="@(body)"
+                      draggable="false"
+                      position="center"
+                      resizable="false"
+                      closable="false"
+                      modal="true"
+                      width="600px"
+                      widgetVar="dlgSinResultados"
+                      header="Informativo"
+                      dynamic="true">
+                <div class="form-group">
+                    <div class="row">
+                        <div class="col-md-12">
+                            <h:outputText styleClass="bloque"
+                                          value="No se encontraron registros para los criterios de búsqueda." />
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-12 text-right">
+                        <p:commandButton value="Cerrar"
+                                         styleClass="btn btn-default"
+                                         onclick="PF('dlgSinResultados').hide()" />
+                    </div>
+                </div>
+            </p:dialog>
         </sec:authorize>
     </ui:fragment>
 </ui:composition>

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -79,7 +79,8 @@
                                 <p:commandButton value="Limpiar campos"
                                                  actionListener="#{consultaBajaUsuariosBean.limpiar}"
                                                  process="@this"
-                                                 update="@form"
+                                                 update=":frmAltasBajas:frmConsultaBaja :frmAltasBajas:frmResultadosBaja"
+                                                 resetValues="true"
                                                  styleClass="btn btn-default" />
 
                                 <p:commandButton id="btnBuscarBajas"

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -81,7 +81,9 @@
                                                  process="@this"
                                                  update=":frmAltasBajas:frmConsultaBaja :frmAltasBajas:frmResultadosBaja"
                                                  resetValues="true"
-                                                 styleClass="btn btn-default" />
+                                                 styleClass="btn btn-default">
+                                    <p:resetInput target=":frmAltasBajas:frmConsultaBaja :frmAltasBajas:frmResultadosBaja" />
+                                </p:commandButton>
 
                                 <p:commandButton id="btnBuscarBajas"
                                                  process="@form"

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/ConsultaBajaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/ConsultaBajaUsuariosBean.java
@@ -9,6 +9,7 @@ import javax.faces.bean.ManagedProperty;
 import javax.faces.bean.ViewScoped;
 
 import org.apache.log4j.Logger;
+import org.primefaces.context.RequestContext;
 
 import mx.gob.sedesol.basegestor.commons.dto.admin.CatalogoComunDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
@@ -46,14 +47,19 @@ public class ConsultaBajaUsuariosBean extends BaseBean {
 
     public void buscar() {
         if (!validarCampos()) {
+            RequestContext.getCurrentInstance().addCallbackParam("sinResultados", false);
             return;
         }
 
         resultados = consultaBajaService.buscarBajas(matricula.trim(), periodoSeleccionado, estatusSeleccionado);
 
-        if (ObjectUtils.isNullOrEmpty(resultados)) {
+        boolean sinResultados = ObjectUtils.isNullOrEmpty(resultados);
+
+        if (sinResultados) {
             agregarMsgInfo("No se encontraron registros", null);
         }
+
+        RequestContext.getCurrentInstance().addCallbackParam("sinResultados", sinResultados);
     }
 
     public void limpiar() {


### PR DESCRIPTION
## Summary
- show the loading modal when searching bajas and trigger the informative dialog when no records are returned
- add callback parameter handling in the consulta de bajas bean to coordinate dialog behavior

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fa7e74d70832fbe471a35caacd4c8)