### PR TITLE
Desactivar persona al registrar baja

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/INuevaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/INuevaBajaRepository.java
@@ -30,6 +30,8 @@ public interface INuevaBajaRepository {
 
     Long obtenerIdPersonaPorMatricula(String matricula);
 
+    void actualizarPersonaInactiva(Long idPersona);
+
     BajaMatriculacionDTO consultarMatriculacionPorEvento(String matricula, Long idEvento);
 
     Integer obtenerIdUsuarioMoodle(String matricula);

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
@@ -158,6 +158,15 @@ public class NuevaBajaRepository implements INuevaBajaRepository {
     }
 
     @Override
+    @Transactional
+    public void actualizarPersonaInactiva(Long idPersona) {
+        String consulta = "UPDATE tbl_persona SET activo = 0 WHERE id_persona = :idPersona";
+        entityManager.createNativeQuery(consulta)
+                .setParameter("idPersona", idPersona)
+                .executeUpdate();
+    }
+
+    @Override
     public BajaMatriculacionDTO consultarMatriculacionPorEvento(String matricula, Long idEvento) {
         if (idEvento == null) {
             return null;

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
@@ -69,6 +69,8 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
             throw new IllegalArgumentException("No se encontró la matrícula proporcionada");
         }
 
+        nuevaBajaRepository.actualizarPersonaInactiva(idPersona);
+
         Long motivoId = nuevaBajaRepository.insertarMotivoBaja(solicitud.getIdTipoBaja(), solicitud.getMotivo());
         Long procesoId = nuevaBajaRepository.obtenerIdProcesoBaja();
 


### PR DESCRIPTION
## Summary
- add repository support to mark personas as inactive when registering a baja
- invoke the update during baja application to ensure selected persona is deactivated

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930bf0d7d88832fbfa339a96dab1b1b)