### PR TITLE
Integrar suspensión de usuarios Moodle en bajas

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/INuevaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/INuevaBajaRepository.java
@@ -36,6 +36,12 @@ public interface INuevaBajaRepository {
 
     Integer obtenerIdUsuarioMoodle(String matricula);
 
+    Integer obtenerIdUsuarioMoodlePorPersonaYEvento(Long idPersona, Long idEvento);
+
+    Long obtenerIdCursoMoodlePorEvento(Long idEvento);
+
+    Integer obtenerIdPlataformaMoodlePorEvento(Long idEvento);
+
     void insertarBaja(BajaAplicacionDTO bajaAplicacionDTO);
 
     BajaMatriculaDetalleDTO consultarDatosPorMatricula(String matricula);

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
@@ -217,6 +217,43 @@ public class NuevaBajaRepository implements INuevaBajaRepository {
     }
 
     @Override
+    public Integer obtenerIdUsuarioMoodlePorPersonaYEvento(Long idPersona, Long idEvento) {
+        String consulta = "SELECT rppm.id_persona_moodle \n"
+                + "FROM tbl_persona tp\n"
+                + "JOIN rel_grupo_participante rgp ON rgp.id_persona_participante = tp.id_persona\n"
+                + "JOIN tbl_grupos tg ON tg.id = rgp.id_grupo\n"
+                + "JOIN tbl_eventos te ON te.id_evento = tg.id_evento\n"
+                + "JOIN rel_personas_plataformas_moodle rppm ON rppm.id_persona = tp.id_persona \n"
+                + "    AND rppm.id_plataforma_moodle = te.id_plataforma_lms_borrador\n"
+                + "WHERE tp.id_persona = :idPersonaMatriculaIngresada \n"
+                + "    AND te.id_evento = :idEventoSelecionado";
+
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("idPersonaMatriculaIngresada", idPersona);
+        query.setParameter("idEventoSelecionado", idEvento);
+        List<?> resultados = query.getResultList();
+        return resultados.isEmpty() ? null : obtenerEntero(resultados.get(0));
+    }
+
+    @Override
+    public Long obtenerIdCursoMoodlePorEvento(Long idEvento) {
+        String consulta = "SELECT te.id_curso_lms_borrador FROM tbl_eventos te WHERE te.id_evento = :idEvento LIMIT 1";
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("idEvento", idEvento);
+        List<?> resultados = query.getResultList();
+        return resultados.isEmpty() ? null : obtenerLong(resultados.get(0));
+    }
+
+    @Override
+    public Integer obtenerIdPlataformaMoodlePorEvento(Long idEvento) {
+        String consulta = "SELECT te.id_plataforma_lms_borrador FROM tbl_eventos te WHERE te.id_evento = :idEvento LIMIT 1";
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("idEvento", idEvento);
+        List<?> resultados = query.getResultList();
+        return resultados.isEmpty() ? null : obtenerEntero(resultados.get(0));
+    }
+
+    @Override
     @Transactional
     public void insertarBaja(BajaAplicacionDTO bajaAplicacionDTO) {
         String consulta = "INSERT INTO rel_persona_bajas (id_persona, motivo_baja_id, proceso_id, id_plan, id_programa, id_evento, id_grupo, id_user_enrolments_lms, usuario_modifico, contabilizar, solicitud)"

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
@@ -2,24 +2,36 @@ package mx.gob.sedesol.basegestor.service.impl.gestionescolar;
 
 import java.util.List;
 
+import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import mx.gob.sedesol.basegestor.commons.dto.NodoDTO;
-import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaMatriculaDetalleDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaAplicacionDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaMatriculaDetalleDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaMatriculacionDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaSolicitudDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.PlanBajaDTO;
+import mx.gob.sedesol.basegestor.commons.dto.ws.moodle.ParametroWSMoodleDTO;
+import mx.gob.sedesol.basegestor.commons.dto.ws.moodle.Usuario;
 import mx.gob.sedesol.basegestor.model.repositories.gestionescolar.INuevaBajaRepository;
+import mx.gob.sedesol.basegestor.service.ParametroWSMoodleService;
 import mx.gob.sedesol.basegestor.service.gestionescolar.NuevaBajaService;
-import org.springframework.transaction.annotation.Transactional;
+import mx.gob.sedesol.basegestor.ws.moodle.clientes.service.ErrorWS;
+import mx.gob.sedesol.basegestor.ws.moodle.clientes.service.client.CursoWS;
+import mx.gob.sedesol.basegestor.ws.moodle.clientes.service.client.UsuarioWSClient;
 
 @Service("nuevaBajaService")
 public class NuevaBajaServiceImpl implements NuevaBajaService {
 
+    private static final Logger LOGGER = Logger.getLogger(NuevaBajaServiceImpl.class);
+
     @Autowired
     private INuevaBajaRepository nuevaBajaRepository;
+
+    @Autowired
+    private ParametroWSMoodleService parametroWSMoodleService;
 
     @Override
     public List<NodoDTO> obtenerTiposBaja() {
@@ -90,7 +102,36 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
             idPrograma = 0L;
         }
 
-        Integer idUsuarioMoodle = matriculado ? nuevaBajaRepository.obtenerIdUsuarioMoodle(solicitud.getMatriculaUsuario()) : 0;
+        Integer idUsuarioMoodle = matriculado
+                ? nuevaBajaRepository.obtenerIdUsuarioMoodlePorPersonaYEvento(idPersona, idEvento)
+                : 0;
+        Integer idUserEnrolmentsLms = 0;
+
+        if (matriculado && idUsuarioMoodle != null && idUsuarioMoodle > 0 && idEvento != null) {
+            try {
+                Long idCursoLms = nuevaBajaRepository.obtenerIdCursoMoodlePorEvento(idEvento);
+                Integer idPlataformaLms = nuevaBajaRepository.obtenerIdPlataformaMoodlePorEvento(idEvento);
+                ParametroWSMoodleDTO plataforma = idPlataformaLms != null
+                        ? parametroWSMoodleService.buscarPorId(idPlataformaLms)
+                        : null;
+
+                if (plataforma != null) {
+                    if (esDefinitiva) {
+                        Usuario usuario = new Usuario();
+                        usuario.setId(idUsuarioMoodle);
+                        usuario.setSuspended(1);
+                        boolean suspendido = new UsuarioWSClient(plataforma).actualizarUsuarioSuspender(usuario);
+                        idUserEnrolmentsLms = suspendido ? 0 : idUserEnrolmentsLms;
+                    } else if (idCursoLms != null) {
+                        Integer idEnrolment = new CursoWS(plataforma)
+                                .suspenderUsuarioEnCurso(idCursoLms.intValue(), idUsuarioMoodle, 1);
+                        idUserEnrolmentsLms = idEnrolment != null ? idEnrolment : 0;
+                    }
+                }
+            } catch (ErrorWS e) {
+                LOGGER.error("Error al suspender usuario en Moodle", e);
+            }
+        }
         int contabilizar = 1;
 
         BajaAplicacionDTO bajaAplicacionDTO = new BajaAplicacionDTO(
@@ -101,7 +142,7 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
                 idPrograma != null ? idPrograma : 0L,
                 idEvento != null ? idEvento : 0L,
                 idGrupo != null ? idGrupo : 0L,
-                idUsuarioMoodle != null ? idUsuarioMoodle : 0,
+                idUserEnrolmentsLms,
                 solicitud.getQuienAplica(),
                 contabilizar,
                 solicitud.getNumeroSolicitud());


### PR DESCRIPTION
## Summary
- obtiene identificadores de Moodle por persona y evento para relacionar las bajas con la plataforma
- integra llamadas a Moodle para suspender usuarios en curso o de forma global según el tipo de baja
- almacena el id de enrolment devuelto por Moodle o lo reinicia en bajas definitivas

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69323b5a11c8832f8da3e668a6576cc2)