### PR TITLE
Integrate Moodle suspension into drop flow

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/INuevaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/INuevaBajaRepository.java
@@ -34,7 +34,11 @@ public interface INuevaBajaRepository {
 
     BajaMatriculacionDTO consultarMatriculacionPorEvento(String matricula, Long idEvento);
 
-    Integer obtenerIdUsuarioMoodle(String matricula);
+    Integer obtenerIdUsuarioMoodle(Long idPersona, Long idEvento);
+
+    Integer obtenerIdCursoMoodle(Long idEvento);
+
+    Integer obtenerIdPlataformaMoodle(Long idEvento);
 
     void insertarBaja(BajaAplicacionDTO bajaAplicacionDTO);
 

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
@@ -206,12 +206,38 @@ public class NuevaBajaRepository implements INuevaBajaRepository {
     }
 
     @Override
-    public Integer obtenerIdUsuarioMoodle(String matricula) {
-        String consulta = "SELECT rppm.id_persona_moodle FROM rel_personas_plataformas_moodle rppm\n"
-                + "    JOIN tbl_persona tp ON tp.id_persona = rppm.id_persona\n"
-                + "WHERE  tp.sso_idUsuario = :matricula LIMIT 1";
+    public Integer obtenerIdUsuarioMoodle(Long idPersona, Long idEvento) {
+        String consulta = "SELECT rppm.id_persona_moodle \n"
+                + "FROM tbl_persona tp\n"
+                + "JOIN rel_grupo_participante rgp ON rgp.id_persona_participante = tp.id_persona\n"
+                + "JOIN tbl_grupos tg ON tg.id = rgp.id_grupo\n"
+                + "JOIN tbl_eventos te ON te.id_evento = tg.id_evento\n"
+                + "JOIN rel_personas_plataformas_moodle rppm ON rppm.id_persona = tp.id_persona \n"
+                + "    AND rppm.id_plataforma_moodle = te.id_plataforma_lms_borrador\n"
+                + "WHERE tp.id_persona = :idPersona\n"
+                + "    AND te.id_evento = :idEvento";
+
         Query query = entityManager.createNativeQuery(consulta);
-        query.setParameter("matricula", matricula);
+        query.setParameter("idPersona", idPersona);
+        query.setParameter("idEvento", idEvento);
+        List<?> resultados = query.getResultList();
+        return resultados.isEmpty() ? null : obtenerEntero(resultados.get(0));
+    }
+
+    @Override
+    public Integer obtenerIdCursoMoodle(Long idEvento) {
+        String consulta = "SELECT te.id_curso_lms_borrador FROM tbl_eventos te WHERE te.id_evento = :idEvento LIMIT 1";
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("idEvento", idEvento);
+        List<?> resultados = query.getResultList();
+        return resultados.isEmpty() ? null : obtenerEntero(resultados.get(0));
+    }
+
+    @Override
+    public Integer obtenerIdPlataformaMoodle(Long idEvento) {
+        String consulta = "SELECT te.id_plataforma_lms_borrador FROM tbl_eventos te WHERE te.id_evento = :idEvento LIMIT 1";
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("idEvento", idEvento);
         List<?> resultados = query.getResultList();
         return resultados.isEmpty() ? null : obtenerEntero(resultados.get(0));
     }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
@@ -2,9 +2,6 @@ package mx.gob.sedesol.basegestor.service.impl.gestionescolar;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import mx.gob.sedesol.basegestor.commons.dto.NodoDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaMatriculaDetalleDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaAplicacionDTO;
@@ -13,13 +10,27 @@ import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaSolicitudDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.PlanBajaDTO;
 import mx.gob.sedesol.basegestor.model.repositories.gestionescolar.INuevaBajaRepository;
 import mx.gob.sedesol.basegestor.service.gestionescolar.NuevaBajaService;
+import mx.gob.sedesol.basegestor.service.ParametroWSMoodleService;
+import mx.gob.sedesol.basegestor.ws.moodle.clientes.model.entities.Usuario;
+import mx.gob.sedesol.basegestor.ws.moodle.clientes.service.client.CursoWS;
+import mx.gob.sedesol.basegestor.ws.moodle.clientes.service.client.UsuarioWSClient;
+import mx.gob.sedesol.basegestor.ws.moodle.clientes.service.util.ErrorWS;
+import mx.gob.sedesol.basegestor.commons.dto.admin.ParametroWSMoodleDTO;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service("nuevaBajaService")
 public class NuevaBajaServiceImpl implements NuevaBajaService {
 
+    private static final Logger LOGGER = Logger.getLogger(NuevaBajaServiceImpl.class);
+
     @Autowired
     private INuevaBajaRepository nuevaBajaRepository;
+
+    @Autowired
+    private ParametroWSMoodleService parametroWSMoodleService;
 
     @Override
     public List<NodoDTO> obtenerTiposBaja() {
@@ -85,12 +96,17 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
 
         boolean esDefinitiva = contieneTexto(solicitud.getNombreTipoBaja(), "definitiva");
         boolean esSinAsignaturas = contieneTexto(solicitud.getNombreTipoBaja(), "sin asignaturas");
+        boolean esTemporalOParcial = contieneTexto(solicitud.getNombreTipoBaja(), "temporal")
+                || contieneTexto(solicitud.getNombreTipoBaja(), "parcial");
 
         if (!matriculado && esDefinitiva) {
             idPrograma = 0L;
         }
 
-        Integer idUsuarioMoodle = matriculado ? nuevaBajaRepository.obtenerIdUsuarioMoodle(solicitud.getMatriculaUsuario()) : 0;
+        Long idEventoBaja = matriculado && matriculacion.getIdEvento() != null ? matriculacion.getIdEvento() : solicitud.getIdEvento();
+        Integer idUsuarioMoodle = idEventoBaja != null ? nuevaBajaRepository.obtenerIdUsuarioMoodle(idPersona, idEventoBaja) : null;
+        Integer idUserEnrolmentsLms = procesarSuspensionEnMoodle(esDefinitiva, esTemporalOParcial, idEventoBaja, idUsuarioMoodle);
+        idUserEnrolmentsLms = idUserEnrolmentsLms != null ? idUserEnrolmentsLms : 0;
         int contabilizar = 1;
 
         BajaAplicacionDTO bajaAplicacionDTO = new BajaAplicacionDTO(
@@ -101,7 +117,7 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
                 idPrograma != null ? idPrograma : 0L,
                 idEvento != null ? idEvento : 0L,
                 idGrupo != null ? idGrupo : 0L,
-                idUsuarioMoodle != null ? idUsuarioMoodle : 0,
+                idUserEnrolmentsLms,
                 solicitud.getQuienAplica(),
                 contabilizar,
                 solicitud.getNumeroSolicitud());
@@ -111,5 +127,50 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
 
     private boolean contieneTexto(String origen, String texto) {
         return origen != null && texto != null && origen.toLowerCase().contains(texto.toLowerCase());
+    }
+
+    private Integer procesarSuspensionEnMoodle(boolean esDefinitiva, boolean esTemporalOParcial, Long idEvento,
+                                               Integer idUsuarioMoodle) {
+        if (idEvento == null || idEvento == 0 || idUsuarioMoodle == null) {
+            return 0;
+        }
+
+        Integer idPlataforma = nuevaBajaRepository.obtenerIdPlataformaMoodle(idEvento);
+        if (idPlataforma == null) {
+            return 0;
+        }
+
+        ParametroWSMoodleDTO plataforma = parametroWSMoodleService.buscarPorId(idPlataforma);
+        if (plataforma == null) {
+            return 0;
+        }
+
+        try {
+            if (esTemporalOParcial) {
+                Integer idCurso = nuevaBajaRepository.obtenerIdCursoMoodle(idEvento);
+                if (idCurso == null) {
+                    throw new IllegalArgumentException("No se encontró el curso en Moodle para el evento seleccionado");
+                }
+                CursoWS cursoWS = new CursoWS(plataforma);
+                return cursoWS.suspenderUsuarioEnCurso(idCurso, idUsuarioMoodle, 1);
+            }
+
+            if (esDefinitiva) {
+                UsuarioWSClient usuarioWSClient = new UsuarioWSClient(plataforma);
+                Usuario usuario = new Usuario();
+                usuario.setId(idUsuarioMoodle);
+                usuario.setSuspended(1);
+                boolean suspendido = usuarioWSClient.actualizarUsuarioSuspender(usuario);
+                if (!suspendido) {
+                    throw new IllegalStateException("No fue posible suspender al usuario en Moodle");
+                }
+                return 0;
+            }
+        } catch (ErrorWS e) {
+            LOGGER.error("Error al comunicarse con Moodle durante la aplicación de la baja", e);
+            throw new IllegalStateException("No se pudo aplicar la baja en Moodle", e);
+        }
+
+        return 0;
     }
 }


### PR DESCRIPTION
## Summary
- add Moodle integration for user withdrawals, calling the appropriate suspension endpoints for partial/temporal and definitive drops
- fetch Moodle identifiers for users, courses, and platforms based on the selected event
- persist the enrolment suspension id returned by Moodle when recording a withdrawal

## Testing
- mvn -pl basegestor -am -DskipTests compile *(fails: module not found in reactor)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693248db72d8832f8700580eed13caa4)