### PR TITLE
Filtra eventos por usuario y valida bajas

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/INuevaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/INuevaBajaRepository.java
@@ -22,7 +22,7 @@ public interface INuevaBajaRepository {
 
     List<String> consultarPeriodosInscripcion();
 
-    List<NodoDTO> consultarEventosPorPeriodoYPrograma(String nombrePeriodo, Long idPrograma);
+    List<NodoDTO> consultarEventosPorPeriodoYPrograma(String nombrePeriodo, Long idPrograma, String matricula);
 
     Long insertarMotivoBaja(Long idTipoBaja, String descripcion);
 
@@ -43,4 +43,6 @@ public interface INuevaBajaRepository {
     void insertarBaja(BajaAplicacionDTO bajaAplicacionDTO);
 
     BajaMatriculaDetalleDTO consultarDatosPorMatricula(String matricula);
+
+    boolean validarPlanYProgramaPorMatricula(String matricula, Long idPlan, Long idPrograma);
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
@@ -113,11 +113,21 @@ public class NuevaBajaRepository implements INuevaBajaRepository {
 
     @SuppressWarnings("unchecked")
     @Override
-    public List<NodoDTO> consultarEventosPorPeriodoYPrograma(String nombrePeriodo, Long idPrograma) {
-        String consulta = "SELECT te.id_evento, te.nombre_ec FROM tbl_eventos te WHERE te.cve_evento_cap LIKE CONCAT('%',:nombrePeriodo,'%') AND te.id_programa = :idPrograma";
+    public List<NodoDTO> consultarEventosPorPeriodoYPrograma(String nombrePeriodo, Long idPrograma, String matricula) {
+        if (matricula == null) {
+            return new ArrayList<>();
+        }
+
+        String consulta = "SELECT DISTINCT te.id_evento, te.nombre_ec FROM tbl_eventos te "
+                + "JOIN tbl_grupos tg ON tg.id_evento = te.id_evento "
+                + "JOIN rel_grupo_participante rgp ON rgp.id_grupo = tg.id "
+                + "JOIN tbl_persona tp ON tp.id_persona = rgp.id_persona_participante "
+                + "WHERE tp.sso_idUsuario = :matricula "
+                + "AND te.cve_evento_cap LIKE CONCAT('%',:nombrePeriodo,'%') AND te.id_programa = :idPrograma";
         Query query = entityManager.createNativeQuery(consulta);
         query.setParameter("nombrePeriodo", nombrePeriodo);
         query.setParameter("idPrograma", idPrograma);
+        query.setParameter("matricula", matricula);
         List<Object[]> resultados = query.getResultList();
         List<NodoDTO> eventos = new ArrayList<>();
 
@@ -305,6 +315,35 @@ public class NuevaBajaRepository implements INuevaBajaRepository {
         dto.setPeriodo(obtenerCadena(fila[5]));
         dto.setIdEvento(obtenerLong(fila[6]));
         return dto;
+    }
+
+    @Override
+    public boolean validarPlanYProgramaPorMatricula(String matricula, Long idPlan, Long idPrograma) {
+        if (idPlan == null && idPrograma == null) {
+            return true;
+        }
+
+        if (matricula == null) {
+            return false;
+        }
+
+        String consulta = "SELECT COUNT(*) FROM tbl_persona tp "
+                + "LEFT JOIN tbl_persona_aspirante tpa ON tpa.id_persona = tp.id_persona "
+                + "WHERE tp.sso_idUsuario = :matricula "
+                + "AND (:idPlanSeleccionado IS NULL OR tpa.id_plan = :idPlanSeleccionado) "
+                + "AND EXISTS(SELECT 1 FROM rel_grupo_participante rgp2 "
+                + "    INNER JOIN tbl_grupos tg2 ON tg2.id = rgp2.id_grupo "
+                + "    INNER JOIN tbl_eventos te2 ON te2.id_evento = tg2.id_evento "
+                + "    WHERE rgp2.id_persona_participante = tp.id_persona "
+                + "      AND (:idProgramaSeleccionado IS NULL OR te2.id_programa = :idProgramaSeleccionado))";
+
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("matricula", matricula);
+        query.setParameter("idPlanSeleccionado", idPlan);
+        query.setParameter("idProgramaSeleccionado", idPrograma);
+
+        Object resultado = query.getSingleResult();
+        return resultado != null && Long.valueOf(resultado.toString()) > 0;
     }
 
     private Integer obtenerEntero(Object valor) {

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/NuevaBajaService.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/NuevaBajaService.java
@@ -21,7 +21,7 @@ public interface NuevaBajaService {
 
     List<String> obtenerPeriodos();
 
-    List<NodoDTO> obtenerEventosPorPeriodoYPrograma(String nombrePeriodo, Long idPrograma);
+    List<NodoDTO> obtenerEventosPorPeriodoYPrograma(String nombrePeriodo, Long idPrograma, String matricula);
 
     BajaMatriculaDetalleDTO obtenerDatosPorMatricula(String matricula);
 

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
@@ -63,8 +63,8 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
     }
 
     @Override
-    public List<NodoDTO> obtenerEventosPorPeriodoYPrograma(String nombrePeriodo, Long idPrograma) {
-        return nuevaBajaRepository.consultarEventosPorPeriodoYPrograma(nombrePeriodo, idPrograma);
+    public List<NodoDTO> obtenerEventosPorPeriodoYPrograma(String nombrePeriodo, Long idPrograma, String matricula) {
+        return nuevaBajaRepository.consultarEventosPorPeriodoYPrograma(nombrePeriodo, idPrograma, matricula);
     }
 
     @Override
@@ -78,6 +78,10 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
         Long idPersona = nuevaBajaRepository.obtenerIdPersonaPorMatricula(solicitud.getMatriculaUsuario());
         if (idPersona == null) {
             throw new IllegalArgumentException("No se encontró la matrícula proporcionada");
+        }
+
+        if (!datosSeleccionadosValidos(solicitud)) {
+            throw new IllegalArgumentException("Los datos seleccionados no corresponden al estudiante");
         }
 
         nuevaBajaRepository.actualizarPersonaInactiva(idPersona);
@@ -123,6 +127,20 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
                 solicitud.getNumeroSolicitud());
 
         nuevaBajaRepository.insertarBaja(bajaAplicacionDTO);
+    }
+
+    private boolean datosSeleccionadosValidos(BajaSolicitudDTO solicitud) {
+        Long idPlanSeleccionado = solicitud.getIdPlan();
+        Long idProgramaSeleccionado = solicitud.getIdPrograma();
+
+        if (idProgramaSeleccionado != null && idProgramaSeleccionado == 0) {
+            idProgramaSeleccionado = null;
+        }
+
+        return nuevaBajaRepository.validarPlanYProgramaPorMatricula(
+                solicitud.getMatriculaUsuario(),
+                idPlanSeleccionado,
+                idProgramaSeleccionado);
     }
 
     private boolean contieneTexto(String origen, String texto) {

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
@@ -141,7 +141,7 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
 
             if (idPeriodo != null && idPrograma != null) {
                 eventos = convertirANodosSelectItem(
-                        nuevaBajaService.obtenerEventosPorPeriodoYPrograma(idPeriodo, idPrograma));
+                        nuevaBajaService.obtenerEventosPorPeriodoYPrograma(idPeriodo, idPrograma, obtenerMatriculaNormalizada()));
             } else if (eventos == null) {
                 eventos = Collections.emptyList();
             }
@@ -269,12 +269,16 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
     private void actualizarEventos() {
         if (idPrograma != null && idPeriodo != null && !idPeriodo.trim().isEmpty()) {
             eventos = convertirANodosSelectItem(
-                    nuevaBajaService.obtenerEventosPorPeriodoYPrograma(idPeriodo, idPrograma));
+                    nuevaBajaService.obtenerEventosPorPeriodoYPrograma(idPeriodo, idPrograma, obtenerMatriculaNormalizada()));
         } else {
             eventos = Collections.emptyList();
         }
         idEvento = null;
         actualizarHabilitacionSecuencial();
+    }
+
+    private String obtenerMatriculaNormalizada() {
+        return matriculaUsuario != null ? matriculaUsuario.trim() : null;
     }
 
     private void deshabilitarListas() {


### PR DESCRIPTION
## Summary
- Filtra los eventos mostrados en la baja para limitarse a aquellos en los que participa la matrícula indicada.
- Valida que el plan y programa seleccionados correspondan al usuario antes de aplicar la baja, permitiendo casos sin asignación explícita.
- Normaliza la matrícula al consultar los eventos disponibles en la interfaz.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693743e2f008832fa3d7c0536f0ed123)