### PR TITLE
Corregir baja definitiva para suspensión global en Moodle

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/INuevaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/INuevaBajaRepository.java
@@ -44,6 +44,8 @@ public interface INuevaBajaRepository {
 
     Integer obtenerIdPlataformaMoodlePorPersona(Long idPersona);
 
+    Integer[] obtenerIdPersonaYPlataformaMoodle(Long idPersona);
+
     void insertarBaja(BajaAplicacionDTO bajaAplicacionDTO);
 
     BajaMatriculaDetalleDTO consultarDatosPorMatricula(String matricula);

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
@@ -277,6 +277,26 @@ public class NuevaBajaRepository implements INuevaBajaRepository {
     }
 
     @Override
+    public Integer[] obtenerIdPersonaYPlataformaMoodle(Long idPersona) {
+        String consulta = "SELECT rppm.id_persona_moodle, rppm.id_plataforma_moodle\n"
+                + "      FROM tbl_persona tp\n"
+                + "      JOIN rel_personas_plataformas_moodle rppm \n"
+                + "          ON rppm.id_persona = tp.id_persona\n"
+                + "      WHERE tp.id_persona = :idPersonaMatriculaIngresada";
+
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("idPersonaMatriculaIngresada", idPersona);
+        List<Object[]> resultados = query.getResultList();
+
+        if (resultados.isEmpty()) {
+            return null;
+        }
+
+        Object[] fila = resultados.get(0);
+        return new Integer[]{obtenerEntero(fila[0]), obtenerEntero(fila[1])};
+    }
+
+    @Override
     @Transactional
     public void insertarBaja(BajaAplicacionDTO bajaAplicacionDTO) {
         String consulta = "INSERT INTO rel_persona_bajas (id_persona, motivo_baja_id, proceso_id, id_plan, id_programa, id_evento, id_grupo, id_user_enrolments_lms, usuario_modifico, contabilizar, solicitud)"

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
@@ -168,20 +168,23 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
     private void aplicarBajaDefinitiva(BajaSolicitudDTO solicitud, Long idPersona, Long motivoId, Long procesoId) {
         Long idPlan = solicitud.getIdPlan() != null ? solicitud.getIdPlan() : 0L;
         Integer[] datosMoodle = nuevaBajaRepository.obtenerIdPersonaYPlataformaMoodle(idPersona);
-        if (datosMoodle == null || datosMoodle[0] == null) {
+        Integer idPersonaMoodle = datosMoodle != null ? datosMoodle[0] : null;
+        Integer idPlataformaMoodle = datosMoodle != null ? datosMoodle[1] : null;
+
+        if (idPersonaMoodle == null) {
             throw new IllegalArgumentException("No se encontró el usuario en Moodle para suspenderlo");
         }
 
-        if (datosMoodle[1] == null) {
+        if (idPlataformaMoodle == null) {
             throw new IllegalArgumentException("No se encontró la plataforma Moodle para la baja solicitada");
         }
 
-        ParametroWSMoodleDTO plataforma = parametroWSMoodleService.buscarPorId(datosMoodle[1]);
+        ParametroWSMoodleDTO plataforma = parametroWSMoodleService.buscarPorId(idPlataformaMoodle);
         if (plataforma == null) {
             throw new IllegalArgumentException("No se encontró la configuración de plataforma Moodle para la baja");
         }
 
-        suspenderUsuarioCompletoEnMoodle(datosMoodle[0], plataforma);
+        suspenderUsuarioCompletoEnMoodle(idPersonaMoodle, plataforma);
 
         BajaAplicacionDTO bajaAplicacionDTO = new BajaAplicacionDTO(
                 idPersona,

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
@@ -167,6 +167,10 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
 
     private void aplicarBajaDefinitiva(BajaSolicitudDTO solicitud, Long idPersona, Long motivoId, Long procesoId) {
         Long idPlan = solicitud.getIdPlan() != null ? solicitud.getIdPlan() : 0L;
+        Long idPrograma = 0L;
+        Long idEvento = 0L;
+        Long idGrupo = 0L;
+        Integer idUserEnrolmentsLms = 0;
         Integer[] datosMoodle = nuevaBajaRepository.obtenerIdPersonaYPlataformaMoodle(idPersona);
         Integer idPersonaMoodle = datosMoodle != null ? datosMoodle[0] : null;
         Integer idPlataformaMoodle = datosMoodle != null ? datosMoodle[1] : null;
@@ -191,10 +195,10 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
                 motivoId,
                 procesoId,
                 idPlan,
-                0L,
-                0L,
-                0L,
-                0,
+                idPrograma,
+                idEvento,
+                idGrupo,
+                idUserEnrolmentsLms,
                 solicitud.getQuienAplica(),
                 1,
                 solicitud.getNumeroSolicitud());

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
@@ -167,9 +167,21 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
 
     private void aplicarBajaDefinitiva(BajaSolicitudDTO solicitud, Long idPersona, Long motivoId, Long procesoId) {
         Long idPlan = solicitud.getIdPlan() != null ? solicitud.getIdPlan() : 0L;
-        Integer idUsuarioMoodle = obtenerIdUsuarioMoodleParaSuspension(true, idPersona, null);
-        ParametroWSMoodleDTO plataforma = obtenerPlataformaMoodle(null, idPersona);
-        suspenderUsuarioCompletoEnMoodle(idUsuarioMoodle, plataforma);
+        Integer[] datosMoodle = nuevaBajaRepository.obtenerIdPersonaYPlataformaMoodle(idPersona);
+        if (datosMoodle == null || datosMoodle[0] == null) {
+            throw new IllegalArgumentException("No se encontró el usuario en Moodle para suspenderlo");
+        }
+
+        if (datosMoodle[1] == null) {
+            throw new IllegalArgumentException("No se encontró la plataforma Moodle para la baja solicitada");
+        }
+
+        ParametroWSMoodleDTO plataforma = parametroWSMoodleService.buscarPorId(datosMoodle[1]);
+        if (plataforma == null) {
+            throw new IllegalArgumentException("No se encontró la configuración de plataforma Moodle para la baja");
+        }
+
+        suspenderUsuarioCompletoEnMoodle(datosMoodle[0], plataforma);
 
         BajaAplicacionDTO bajaAplicacionDTO = new BajaAplicacionDTO(
                 idPersona,


### PR DESCRIPTION
## Summary
- agregar consulta específica para obtener id_persona_moodle e id_plataforma_moodle por persona
- actualizar la baja definitiva para usar suspensión global en Moodle sin depender de eventos

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939e9c34f28832fa3903888b1c6073e)