### PR TITLE
Implementar eliminación en consulta de bajas

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/ConsultaBajaDTO.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/ConsultaBajaDTO.java
@@ -3,6 +3,7 @@ package mx.gob.sedesol.basegestor.commons.dto.gestionescolar;
 public class ConsultaBajaDTO {
 
     private Integer idBaja;
+    private Long idPersona;
     private String matricula;
     private String plan;
     private String programa;
@@ -26,6 +27,14 @@ public class ConsultaBajaDTO {
 
     public void setIdBaja(Integer idBaja) {
         this.idBaja = idBaja;
+    }
+
+    public Long getIdPersona() {
+        return idPersona;
+    }
+
+    public void setIdPersona(Long idPersona) {
+        this.idPersona = idPersona;
     }
 
     public String getPlan() {

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/ConsultaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/ConsultaBajaRepository.java
@@ -23,6 +23,7 @@ public class ConsultaBajaRepository implements IConsultaBajaRepository {
     public List<ConsultaBajaDTO> buscarBajas(String matricula, String periodo, Integer estatus) {
 
         String consulta = "SELECT rpb.id_baja AS id_baja, "
+                + " tp.id_persona AS id_persona, "
                 + " tp.sso_idUsuario AS matricula, "
                 + " tpl.nombre AS plan, "
                 + " tfdp.nombre_tentativo AS programa, "
@@ -56,14 +57,15 @@ public class ConsultaBajaRepository implements IConsultaBajaRepository {
             for (Object[] registro : resultados) {
                 ConsultaBajaDTO dto = new ConsultaBajaDTO();
                 dto.setIdBaja(registro[0] != null ? Integer.valueOf(registro[0].toString()) : null);
-                dto.setMatricula(registro[1] != null ? registro[1].toString() : "");
-                dto.setPlan(registro[2] != null ? registro[2].toString() : "");
-                dto.setPrograma(registro[3] != null ? registro[3].toString() : "");
-                dto.setEvento(registro[4] != null ? registro[4].toString() : "");
-                dto.setTipoBaja(registro[5] != null ? registro[5].toString() : "");
-                dto.setEstructura(registro[6] != null ? registro[6].toString() : "");
-                dto.setPeriodo(registro[7] != null ? registro[7].toString() : "");
-                dto.setEstatus(registro[8] != null ? Integer.valueOf(registro[8].toString()) : null);
+                dto.setIdPersona(registro[1] != null ? Long.valueOf(registro[1].toString()) : null);
+                dto.setMatricula(registro[2] != null ? registro[2].toString() : "");
+                dto.setPlan(registro[3] != null ? registro[3].toString() : "");
+                dto.setPrograma(registro[4] != null ? registro[4].toString() : "");
+                dto.setEvento(registro[5] != null ? registro[5].toString() : "");
+                dto.setTipoBaja(registro[6] != null ? registro[6].toString() : "");
+                dto.setEstructura(registro[7] != null ? registro[7].toString() : "");
+                dto.setPeriodo(registro[8] != null ? registro[8].toString() : "");
+                dto.setEstatus(registro[9] != null ? Integer.valueOf(registro[9].toString()) : null);
                 bajas.add(dto);
             }
         }
@@ -89,5 +91,19 @@ public class ConsultaBajaRepository implements IConsultaBajaRepository {
         }
 
         return periodos;
+    }
+
+    @Override
+    @javax.transaction.Transactional
+    public void eliminarBaja(Integer idBaja, Long idPersona, boolean esBajaDefinitiva) {
+        entityManager.createNativeQuery("DELETE FROM rel_persona_bajas WHERE id_baja = :idBaja")
+                .setParameter("idBaja", idBaja)
+                .executeUpdate();
+
+        if (esBajaDefinitiva && idPersona != null) {
+            entityManager.createNativeQuery("UPDATE tbl_persona SET activo = 1 WHERE id_persona = :idPersona")
+                    .setParameter("idPersona", idPersona)
+                    .executeUpdate();
+        }
     }
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/IConsultaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/IConsultaBajaRepository.java
@@ -10,4 +10,6 @@ public interface IConsultaBajaRepository {
     List<ConsultaBajaDTO> buscarBajas(String matricula, String periodo, Integer estatus);
 
     List<CatalogoComunDTO> obtenerPeriodos();
+
+    void eliminarBaja(Integer idBaja, Long idPersona, boolean esBajaDefinitiva);
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/ConsultaBajaService.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/ConsultaBajaService.java
@@ -10,4 +10,6 @@ public interface ConsultaBajaService {
     List<ConsultaBajaDTO> buscarBajas(String matricula, String periodo, Integer estatus);
 
     List<CatalogoComunDTO> obtenerPeriodos();
+
+    void eliminarBaja(ConsultaBajaDTO baja);
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/ConsultaBajaServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/ConsultaBajaServiceImpl.java
@@ -39,4 +39,20 @@ public class ConsultaBajaServiceImpl implements ConsultaBajaService {
             return new ArrayList<>();
         }
     }
+
+    @Override
+    public void eliminarBaja(ConsultaBajaDTO baja) {
+        try {
+            if (baja == null || baja.getIdBaja() == null) {
+                throw new IllegalArgumentException("No se proporcionó la baja a eliminar");
+            }
+
+            boolean esBajaDefinitiva = baja != null && baja.getTipoBaja() != null
+                    && baja.getTipoBaja().toLowerCase().contains("definitiva");
+            consultaBajaRepository.eliminarBaja(baja.getIdBaja(), baja.getIdPersona(), esBajaDefinitiva);
+        } catch (Exception ex) {
+            LOGGER.error("Error al eliminar la baja de usuario", ex);
+            throw ex;
+        }
+    }
 }

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -184,12 +184,53 @@
                                     <p:commandButton type="button"
                                                      icon="fa fa-trash"
                                                      styleClass="btn-icon btn btn-default"
-                                                     title="Eliminar" />
+                                                     title="Eliminar"
+                                                     process="@this"
+                                                     update=":frmAltasBajas:frmResultadosBaja:dlgEliminarBaja"
+                                                     actionListener="#{consultaBajaUsuariosBean.prepararEliminacion(baja)}"
+                                                     oncomplete="PF('dlgEliminarBaja').show();" />
                                 </p:column>
                             </p:dataTable>
                         </div>
                     </div>
                 </p:panel>
+
+                <p:dialog appendTo="@(body)"
+                      draggable="false"
+                      position="center"
+                      resizable="false"
+                      closable="true"
+                      modal="true"
+                      width="450px"
+                      widgetVar="dlgEliminarBaja"
+                      id="dlgEliminarBaja"
+                      header="Confirmar eliminación">
+                <h:panelGroup rendered="#{not empty consultaBajaUsuariosBean.bajaSeleccionada}">
+                    <div class="form-group">
+                        <div class="row">
+                            <div class="col-md-12">
+                                <h:outputText styleClass="bloque"
+                                              value="¿Desea eliminar la baja del usuario #{consultaBajaUsuariosBean.bajaSeleccionada.matricula}?" />
+                            </div>
+                        </div>
+                    </div>
+                </h:panelGroup>
+
+                <div class="row">
+                    <div class="col-md-12 text-right">
+                        <p:commandButton value="Cancelar"
+                                         type="button"
+                                         styleClass="btn btn-default"
+                                         onclick="PF('dlgEliminarBaja').hide();" />
+                        <p:commandButton value="Aceptar"
+                                         styleClass="btn btn-primary"
+                                         process="@this"
+                                         actionListener="#{consultaBajaUsuariosBean.eliminar}"
+                                         update=":frmAltasBajas:frmConsultaBaja :frmAltasBajas:frmResultadosBaja"
+                                         oncomplete="PF('dlgEliminarBaja').hide();" />
+                    </div>
+                </div>
+                </p:dialog>
             </h:form>
 
             <p:dialog appendTo="@(body)"

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/ConsultaBajaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/ConsultaBajaUsuariosBean.java
@@ -33,6 +33,7 @@ public class ConsultaBajaUsuariosBean extends BaseBean {
     private Integer estatusSeleccionado;
     private List<CatalogoComunDTO> periodos;
     private List<ConsultaBajaDTO> resultados;
+    private ConsultaBajaDTO bajaSeleccionada;
 
     @PostConstruct
     public void init() {
@@ -67,6 +68,7 @@ public class ConsultaBajaUsuariosBean extends BaseBean {
         periodoSeleccionado = null;
         estatusSeleccionado = null;
         resultados = new ArrayList<>();
+        bajaSeleccionada = null;
     }
 
     public String obtenerNombreEstatus(Integer estatus) {
@@ -97,6 +99,27 @@ public class ConsultaBajaUsuariosBean extends BaseBean {
         }
 
         return valido;
+    }
+
+    public void prepararEliminacion(ConsultaBajaDTO baja) {
+        bajaSeleccionada = baja;
+    }
+
+    public void eliminar() {
+        try {
+            if (bajaSeleccionada == null || bajaSeleccionada.getIdBaja() == null) {
+                agregarMsgError("Seleccione un registro válido para eliminar.", null);
+                return;
+            }
+
+            consultaBajaService.eliminarBaja(bajaSeleccionada);
+            agregarMsgInfo("La baja se elimin\u00f3 correctamente.", null);
+            buscar();
+            bajaSeleccionada = null;
+        } catch (Exception e) {
+            LOGGER.error("Error al eliminar la baja", e);
+            agregarMsgError("Ocurri\u00f3 un error al eliminar la baja.", null);
+        }
     }
 
     public String getMatricula() {
@@ -137,6 +160,14 @@ public class ConsultaBajaUsuariosBean extends BaseBean {
 
     public void setResultados(List<ConsultaBajaDTO> resultados) {
         this.resultados = resultados;
+    }
+
+    public ConsultaBajaDTO getBajaSeleccionada() {
+        return bajaSeleccionada;
+    }
+
+    public void setBajaSeleccionada(ConsultaBajaDTO bajaSeleccionada) {
+        this.bajaSeleccionada = bajaSeleccionada;
     }
 
     public ConsultaBajaService getConsultaBajaService() {


### PR DESCRIPTION
## Summary
- agregar soporte backend para eliminar bajas y reactivar persona en casos definitivos
- exponer acción de eliminación en la tabla de consulta de bajas con confirmación y refresco

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a50cba2c832fa883a868bd367a1f)