### PR TITLE
Implement edit and delete workflows for consulta de bajas

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/ConsultaBajaDTO.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/gestionescolar/ConsultaBajaDTO.java
@@ -11,6 +11,20 @@ public class ConsultaBajaDTO {
     private String estructura;
     private String periodo;
     private Integer estatus;
+    private Long idPlan;
+    private Long idPrograma;
+    private Long idEvento;
+    private Long idSemestre;
+    private Long idBloque;
+    private Long idPersona;
+    private Integer idUserEnrolmentsLms;
+    private Integer idTipoBaja;
+    private Long idMotivoBaja;
+    private String motivo;
+    private String numeroSolicitud;
+    private String quienAplica;
+    private String nombreEstudiante;
+    private Long idGrupo;
 
     public String getMatricula() {
         return matricula;
@@ -82,5 +96,117 @@ public class ConsultaBajaDTO {
 
     public void setEstatus(Integer estatus) {
         this.estatus = estatus;
+    }
+
+    public Long getIdPlan() {
+        return idPlan;
+    }
+
+    public void setIdPlan(Long idPlan) {
+        this.idPlan = idPlan;
+    }
+
+    public Long getIdPrograma() {
+        return idPrograma;
+    }
+
+    public void setIdPrograma(Long idPrograma) {
+        this.idPrograma = idPrograma;
+    }
+
+    public Long getIdEvento() {
+        return idEvento;
+    }
+
+    public void setIdEvento(Long idEvento) {
+        this.idEvento = idEvento;
+    }
+
+    public Long getIdSemestre() {
+        return idSemestre;
+    }
+
+    public void setIdSemestre(Long idSemestre) {
+        this.idSemestre = idSemestre;
+    }
+
+    public Long getIdBloque() {
+        return idBloque;
+    }
+
+    public void setIdBloque(Long idBloque) {
+        this.idBloque = idBloque;
+    }
+
+    public Long getIdPersona() {
+        return idPersona;
+    }
+
+    public void setIdPersona(Long idPersona) {
+        this.idPersona = idPersona;
+    }
+
+    public Integer getIdUserEnrolmentsLms() {
+        return idUserEnrolmentsLms;
+    }
+
+    public void setIdUserEnrolmentsLms(Integer idUserEnrolmentsLms) {
+        this.idUserEnrolmentsLms = idUserEnrolmentsLms;
+    }
+
+    public Integer getIdTipoBaja() {
+        return idTipoBaja;
+    }
+
+    public void setIdTipoBaja(Integer idTipoBaja) {
+        this.idTipoBaja = idTipoBaja;
+    }
+
+    public Long getIdMotivoBaja() {
+        return idMotivoBaja;
+    }
+
+    public void setIdMotivoBaja(Long idMotivoBaja) {
+        this.idMotivoBaja = idMotivoBaja;
+    }
+
+    public String getMotivo() {
+        return motivo;
+    }
+
+    public void setMotivo(String motivo) {
+        this.motivo = motivo;
+    }
+
+    public String getNumeroSolicitud() {
+        return numeroSolicitud;
+    }
+
+    public void setNumeroSolicitud(String numeroSolicitud) {
+        this.numeroSolicitud = numeroSolicitud;
+    }
+
+    public String getQuienAplica() {
+        return quienAplica;
+    }
+
+    public void setQuienAplica(String quienAplica) {
+        this.quienAplica = quienAplica;
+    }
+
+    public String getNombreEstudiante() {
+        return nombreEstudiante;
+    }
+
+    public void setNombreEstudiante(String nombreEstudiante) {
+        this.nombreEstudiante = nombreEstudiante;
+    }
+
+    public Long getIdGrupo() {
+        return idGrupo;
+    }
+
+    public void setIdGrupo(Long idGrupo) {
+        this.idGrupo = idGrupo;
     }
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/ConsultaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/ConsultaBajaRepository.java
@@ -24,13 +24,27 @@ public class ConsultaBajaRepository implements IConsultaBajaRepository {
 
         String consulta = "SELECT rpb.id_baja AS id_baja, "
                 + " tp.sso_idUsuario AS matricula, "
+                + " CONCAT(tp.sso_nombre, ' ', tp.sso_apellidoPaterno, IF(tp.sso_apellidoMaterno != '', CONCAT(' ', tp.sso_apellidoMaterno),'')) AS nombre_estudiante, "
                 + " tpl.nombre AS plan, "
                 + " tfdp.nombre_tentativo AS programa, "
                 + " te.nombre_ec AS evento, "
                 + " ctb.nombre AS tipo_baja, "
                 + " CONCAT((SELECT tmc2.nombre FROM tbl_malla_curricular tmc2 WHERE tmc2.id = tmc.id_padre),' ', tmc.nombre) AS estructura, "
                 + " tpi.nombre_periodo AS periodo, "
-                + " rpb.contabilizar AS estatus "
+                + " rpb.contabilizar AS estatus, "
+                + " rpb.id_plan AS id_plan, "
+                + " rpb.id_programa AS id_programa, "
+                + " rpb.id_evento AS id_evento, "
+                + " tmc.id AS id_bloque, "
+                + " tmc.id_padre AS id_semestre, "
+                + " tp.id_persona AS id_persona, "
+                + " rpb.id_user_enrolments_lms AS id_user_enrolments_lms, "
+                + " ctb.id_tipo_baja AS id_tipo_baja, "
+                + " rmb.id_motivo_baja AS id_motivo_baja, "
+                + " rmb.descripcion AS motivo, "
+                + " rpb.solicitud AS numero_solicitud, "
+                + " rpb.usuario_modifico AS quien_aplica, "
+                + " rpb.id_grupo AS id_grupo "
                 + "FROM rel_persona_bajas rpb "
                 + " JOIN tbl_persona tp ON tp.id_persona = rpb.id_persona "
                 + " JOIN tbl_planes tpl ON tpl.id_plan = rpb.id_plan "
@@ -57,13 +71,27 @@ public class ConsultaBajaRepository implements IConsultaBajaRepository {
                 ConsultaBajaDTO dto = new ConsultaBajaDTO();
                 dto.setIdBaja(registro[0] != null ? Integer.valueOf(registro[0].toString()) : null);
                 dto.setMatricula(registro[1] != null ? registro[1].toString() : "");
-                dto.setPlan(registro[2] != null ? registro[2].toString() : "");
-                dto.setPrograma(registro[3] != null ? registro[3].toString() : "");
-                dto.setEvento(registro[4] != null ? registro[4].toString() : "");
-                dto.setTipoBaja(registro[5] != null ? registro[5].toString() : "");
-                dto.setEstructura(registro[6] != null ? registro[6].toString() : "");
-                dto.setPeriodo(registro[7] != null ? registro[7].toString() : "");
-                dto.setEstatus(registro[8] != null ? Integer.valueOf(registro[8].toString()) : null);
+                dto.setNombreEstudiante(registro[2] != null ? registro[2].toString() : "");
+                dto.setPlan(registro[3] != null ? registro[3].toString() : "");
+                dto.setPrograma(registro[4] != null ? registro[4].toString() : "");
+                dto.setEvento(registro[5] != null ? registro[5].toString() : "");
+                dto.setTipoBaja(registro[6] != null ? registro[6].toString() : "");
+                dto.setEstructura(registro[7] != null ? registro[7].toString() : "");
+                dto.setPeriodo(registro[8] != null ? registro[8].toString() : "");
+                dto.setEstatus(registro[9] != null ? Integer.valueOf(registro[9].toString()) : null);
+                dto.setIdPlan(registro[10] != null ? Long.valueOf(registro[10].toString()) : null);
+                dto.setIdPrograma(registro[11] != null ? Long.valueOf(registro[11].toString()) : null);
+                dto.setIdEvento(registro[12] != null ? Long.valueOf(registro[12].toString()) : null);
+                dto.setIdBloque(registro[13] != null ? Long.valueOf(registro[13].toString()) : null);
+                dto.setIdSemestre(registro[14] != null ? Long.valueOf(registro[14].toString()) : null);
+                dto.setIdPersona(registro[15] != null ? Long.valueOf(registro[15].toString()) : null);
+                dto.setIdUserEnrolmentsLms(registro[16] != null ? Integer.valueOf(registro[16].toString()) : null);
+                dto.setIdTipoBaja(registro[17] != null ? Integer.valueOf(registro[17].toString()) : null);
+                dto.setIdMotivoBaja(registro[18] != null ? Long.valueOf(registro[18].toString()) : null);
+                dto.setMotivo(registro[19] != null ? registro[19].toString() : "");
+                dto.setNumeroSolicitud(registro[20] != null ? registro[20].toString() : "");
+                dto.setQuienAplica(registro[21] != null ? registro[21].toString() : "");
+                dto.setIdGrupo(registro[22] != null ? Long.valueOf(registro[22].toString()) : null);
                 bajas.add(dto);
             }
         }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/INuevaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/INuevaBajaRepository.java
@@ -48,4 +48,12 @@ public interface INuevaBajaRepository {
     void insertarBaja(BajaAplicacionDTO bajaAplicacionDTO);
 
     BajaMatriculaDetalleDTO consultarDatosPorMatricula(String matricula);
+
+    void actualizarBaja(Long idBaja, BajaAplicacionDTO bajaAplicacionDTO);
+
+    void eliminarBaja(Long idBaja);
+
+    void actualizarMotivoBaja(Long idMotivoBaja, Long idTipoBaja, String descripcion);
+
+    void reactivarPersona(Long idPersona);
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
@@ -361,4 +361,58 @@ public class NuevaBajaRepository implements INuevaBajaRepository {
     private Long obtenerLong(Object valor) {
         return valor != null ? Long.valueOf(valor.toString()) : null;
     }
+
+    @Override
+    @Transactional
+    public void actualizarBaja(Long idBaja, BajaAplicacionDTO bajaAplicacionDTO) {
+        String consulta = "UPDATE rel_persona_bajas "
+                + "SET motivo_baja_id = :motivoBajaId, proceso_id = :procesoId, "
+                + "id_plan = :idPlan, id_programa = :idPrograma, id_evento = :idEvento, id_grupo = :idGrupo, "
+                + "id_user_enrolments_lms = :idUserEnrolmentsLms, usuario_modifico = :usuarioModifico, "
+                + "contabilizar = :contabilizar, solicitud = :numeroSolicitud "
+                + "WHERE id_baja = :idBaja";
+
+        entityManager.createNativeQuery(consulta)
+                .setParameter("motivoBajaId", bajaAplicacionDTO.getMotivoBajaId())
+                .setParameter("procesoId", bajaAplicacionDTO.getProcesoId())
+                .setParameter("idPlan", bajaAplicacionDTO.getIdPlan())
+                .setParameter("idPrograma", bajaAplicacionDTO.getIdPrograma())
+                .setParameter("idEvento", bajaAplicacionDTO.getIdEvento())
+                .setParameter("idGrupo", bajaAplicacionDTO.getIdGrupo())
+                .setParameter("idUserEnrolmentsLms", bajaAplicacionDTO.getIdUserEnrolmentsLms())
+                .setParameter("usuarioModifico", bajaAplicacionDTO.getQuienAplicaBaja() != null ? bajaAplicacionDTO.getQuienAplicaBaja() : "-")
+                .setParameter("contabilizar", bajaAplicacionDTO.getContabilizar())
+                .setParameter("numeroSolicitud", bajaAplicacionDTO.getNumeroSolicitud())
+                .setParameter("idBaja", idBaja)
+                .executeUpdate();
+    }
+
+    @Override
+    @Transactional
+    public void eliminarBaja(Long idBaja) {
+        String consulta = "DELETE FROM rel_persona_bajas WHERE id_baja = :idBaja";
+        entityManager.createNativeQuery(consulta)
+                .setParameter("idBaja", idBaja)
+                .executeUpdate();
+    }
+
+    @Override
+    @Transactional
+    public void actualizarMotivoBaja(Long idMotivoBaja, Long idTipoBaja, String descripcion) {
+        String consulta = "UPDATE rel_motivo_baja SET tipo_baja_id = :idTipoBaja, descripcion = :descripcion WHERE id_motivo_baja = :idMotivoBaja";
+        entityManager.createNativeQuery(consulta)
+                .setParameter("idTipoBaja", idTipoBaja)
+                .setParameter("descripcion", descripcion)
+                .setParameter("idMotivoBaja", idMotivoBaja)
+                .executeUpdate();
+    }
+
+    @Override
+    @Transactional
+    public void reactivarPersona(Long idPersona) {
+        String consulta = "UPDATE tbl_persona SET activo = 1 WHERE id_persona = :idPersona";
+        entityManager.createNativeQuery(consulta)
+                .setParameter("idPersona", idPersona)
+                .executeUpdate();
+    }
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/NuevaBajaService.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/NuevaBajaService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import mx.gob.sedesol.basegestor.commons.dto.NodoDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaMatriculaDetalleDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaSolicitudDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.PlanBajaDTO;
 
 public interface NuevaBajaService {
@@ -26,4 +27,8 @@ public interface NuevaBajaService {
     BajaMatriculaDetalleDTO obtenerDatosPorMatricula(String matricula);
 
     void aplicarBaja(BajaSolicitudDTO solicitud);
+
+    void actualizarBaja(Long idBaja, BajaSolicitudDTO solicitud, Long idMotivoBaja);
+
+    void eliminarBaja(ConsultaBajaDTO baja);
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
@@ -7,11 +7,13 @@ import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaMatriculaDetalle
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaAplicacionDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaMatriculacionDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaSolicitudDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.DatosMoodlePersonaDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.PlanBajaDTO;
 import mx.gob.sedesol.basegestor.model.repositories.gestionescolar.INuevaBajaRepository;
 import mx.gob.sedesol.basegestor.service.gestionescolar.NuevaBajaService;
 import mx.gob.sedesol.basegestor.service.ParametroWSMoodleService;
+import mx.gob.sedesol.basegestor.ws.moodle.clientes.model.entities.Usuario;
 import mx.gob.sedesol.basegestor.ws.moodle.clientes.service.client.CursoWS;
 import mx.gob.sedesol.basegestor.ws.moodle.clientes.service.client.UsuarioWSClient;
 import mx.gob.sedesol.basegestor.ws.moodle.clientes.service.util.ErrorWS;
@@ -75,6 +77,50 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
     @Override
     @Transactional
     public void aplicarBaja(BajaSolicitudDTO solicitud) {
+        procesarBaja(solicitud, null, null);
+    }
+
+    @Override
+    @Transactional
+    public void actualizarBaja(Long idBaja, BajaSolicitudDTO solicitud, Long idMotivoBaja) {
+        if (idBaja == null) {
+            throw new IllegalArgumentException("El identificador de la baja es obligatorio para actualizarla");
+        }
+        procesarBaja(solicitud, idBaja, idMotivoBaja);
+    }
+
+    @Override
+    @Transactional
+    public void eliminarBaja(ConsultaBajaDTO baja) {
+        Long idPersona = baja.getIdPersona() != null ? baja.getIdPersona()
+                : nuevaBajaRepository.obtenerIdPersonaPorMatricula(baja.getMatricula());
+        if (idPersona == null) {
+            throw new IllegalArgumentException("No se encontró la matrícula proporcionada");
+        }
+
+        boolean esDefinitiva = contieneTexto(baja.getTipoBaja(), "definitiva");
+        boolean esTemporalOParcial = contieneTexto(baja.getTipoBaja(), "temporal")
+                || contieneTexto(baja.getTipoBaja(), "parcial");
+
+        nuevaBajaRepository.reactivarPersona(idPersona);
+
+        if (esTemporalOParcial && baja.getIdEvento() != null) {
+            reactivarUsuarioEnCurso(baja.getIdEvento(), idPersona);
+        } else if (esDefinitiva) {
+            try {
+                reactivarUsuarioDefinitivamente(idPersona);
+            } catch (Exception e) {
+                LOGGER.error("No se pudo reactivar al usuario en Moodle", e);
+                throw e;
+            }
+        }
+
+        if (baja.getIdBaja() != null) {
+            nuevaBajaRepository.eliminarBaja(baja.getIdBaja().longValue());
+        }
+    }
+
+    private void procesarBaja(BajaSolicitudDTO solicitud, Long idBaja, Long idMotivoBaja) {
         Long idPersona = nuevaBajaRepository.obtenerIdPersonaPorMatricula(solicitud.getMatriculaUsuario());
         if (idPersona == null) {
             throw new IllegalArgumentException("No se encontró la matrícula proporcionada");
@@ -82,7 +128,13 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
 
         nuevaBajaRepository.actualizarPersonaInactiva(idPersona);
 
-        Long motivoId = nuevaBajaRepository.insertarMotivoBaja(solicitud.getIdTipoBaja(), solicitud.getMotivo());
+        Long motivoId = idMotivoBaja != null ? idMotivoBaja
+                : nuevaBajaRepository.insertarMotivoBaja(solicitud.getIdTipoBaja(), solicitud.getMotivo());
+
+        if (idMotivoBaja != null) {
+            nuevaBajaRepository.actualizarMotivoBaja(idMotivoBaja, solicitud.getIdTipoBaja(), solicitud.getMotivo());
+        }
+
         Long procesoId = nuevaBajaRepository.obtenerIdProcesoBaja();
 
         BajaMatriculacionDTO matriculacion = solicitud.getIdEvento() != null
@@ -156,7 +208,13 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
                 contabilizar,
                 solicitud.getNumeroSolicitud());
 
-        nuevaBajaRepository.insertarBaja(bajaAplicacionDTO);
+        if (idBaja == null) {
+            nuevaBajaRepository.insertarBaja(bajaAplicacionDTO);
+        } else {
+            bajaAplicacionDTO.setMotivoBajaId(motivoId);
+            bajaAplicacionDTO.setQuienAplicaBaja(solicitud.getQuienAplica());
+            nuevaBajaRepository.actualizarBaja(idBaja, bajaAplicacionDTO);
+        }
 
     }
 
@@ -262,5 +320,55 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
             throw new IllegalArgumentException("No se encontró la relación del usuario con Moodle");
         }
         return datosMoodle.get(0);
+    }
+
+    private void reactivarUsuarioEnCurso(Long idEvento, Long idPersona) {
+        Integer idUsuarioMoodle = nuevaBajaRepository.obtenerIdUsuarioMoodle(idPersona, idEvento);
+        if (idUsuarioMoodle == null) {
+            throw new IllegalArgumentException("No se encontró el usuario en Moodle para el evento seleccionado");
+        }
+        Integer idPlataforma = nuevaBajaRepository.obtenerIdPlataformaMoodle(idEvento);
+        if (idPlataforma == null) {
+            throw new IllegalArgumentException("No se encontró la plataforma de Moodle para el evento seleccionado");
+        }
+        ParametroWSMoodleDTO plataforma = parametroWSMoodleService.buscarPorId(idPlataforma);
+        if (plataforma == null) {
+            throw new IllegalArgumentException("No se encontró la configuración de la plataforma Moodle");
+        }
+        try {
+            Integer idCurso = nuevaBajaRepository.obtenerIdCursoMoodle(idEvento);
+            if (idCurso == null) {
+                throw new IllegalArgumentException("No se encontró el curso en Moodle para el evento seleccionado");
+            }
+            CursoWS cursoWS = new CursoWS(plataforma);
+            Integer respuesta = cursoWS.suspenderUsuarioEnCurso(idCurso, idUsuarioMoodle, 0);
+            if (respuesta == null) {
+                throw new IllegalStateException("No fue posible reactivar al usuario en el curso de Moodle");
+            }
+        } catch (ErrorWS e) {
+            LOGGER.error("Error al reactivar al usuario en el curso de Moodle", e);
+            throw new IllegalStateException("No se pudo reactivar al usuario en el curso de Moodle", e);
+        }
+    }
+
+    private void reactivarUsuarioDefinitivamente(Long idPersona) {
+        DatosMoodlePersonaDTO datosMoodle = obtenerDatosMoodle(idPersona);
+        if (datosMoodle == null || datosMoodle.getIdPersonaMoodle() == null) {
+            throw new IllegalArgumentException("No se encontró el usuario en Moodle para reactivarlo");
+        }
+        ParametroWSMoodleDTO plataforma = parametroWSMoodleService.buscarPorId(datosMoodle.getIdPlataformaMoodle());
+        if (plataforma == null) {
+            throw new IllegalArgumentException("No se encontró la configuración de la plataforma Moodle");
+        }
+        UsuarioWSClient usuarioWSClient = new UsuarioWSClient(plataforma);
+        Usuario usuario = new Usuario();
+        usuario.setId(datosMoodle.getIdPersonaMoodle());
+        usuario.setSuspended(0);
+        try {
+            usuarioWSClient.actualizarUsuarioSuspender(usuario);
+        } catch (ErrorWS e) {
+            LOGGER.error("Error al reactivar al usuario en Moodle", e);
+            throw new IllegalStateException("No se pudo reactivar al usuario en Moodle", e);
+        }
     }
 }

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -103,6 +103,10 @@
             <h:form id="frmResultadosBaja">
                 <p:panel header="Listado de bajas encontradas"
                          styleClass="panel-primary">
+                    <p:messages id="msgsResultadosBaja"
+                                 autoUpdate="true"
+                                 closable="true"
+                                 for="@form" />
                     <div class="row">
                         <div class="col-md-12">
                             <p:dataTable id="tablaBajas"
@@ -176,15 +180,20 @@
                                         <h:outputText value="Acciones" />
                                     </f:facet>
 
-                                    <p:commandButton type="button"
-                                                     icon="fa fa-pencil"
+                                    <p:commandButton icon="fa fa-pencil"
                                                      styleClass="btn-icon btn btn-default"
-                                                     title="Editar" />
+                                                     title="Editar"
+                                                     rendered="#{baja.estatus == 0}"
+                                                     process="@this"
+                                                     update=":frmAltasBajas:panelBotones :frmAltasBajas:panelContenido"
+                                                     actionListener="#{consultaBajaUsuariosBean.editar(baja)}" />
 
-                                    <p:commandButton type="button"
-                                                     icon="fa fa-trash"
+                                    <p:commandButton icon="fa fa-trash"
                                                      styleClass="btn-icon btn btn-default"
-                                                     title="Eliminar" />
+                                                     title="Eliminar"
+                                                     process="@this"
+                                                     update=":frmAltasBajas:frmResultadosBaja"
+                                                     actionListener="#{consultaBajaUsuariosBean.eliminar(baja)}" />
                                 </p:column>
                             </p:dataTable>
                         </div>

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/ConsultaBajaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/ConsultaBajaUsuariosBean.java
@@ -15,7 +15,10 @@ import mx.gob.sedesol.basegestor.commons.dto.admin.CatalogoComunDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
 import mx.gob.sedesol.basegestor.commons.utils.ObjectUtils;
 import mx.gob.sedesol.basegestor.service.gestionescolar.ConsultaBajaService;
+import mx.gob.sedesol.basegestor.service.gestionescolar.NuevaBajaService;
 import mx.gob.sedesol.gestorweb.beans.acceso.BaseBean;
+import mx.gob.sedesol.gestorweb.beans.gestionescolar.AltasBajasUsuariosBean;
+import mx.gob.sedesol.gestorweb.beans.gestionescolar.NuevaBajaUsuarioBean;
 
 @ManagedBean
 @ViewScoped
@@ -27,6 +30,15 @@ public class ConsultaBajaUsuariosBean extends BaseBean {
 
     @ManagedProperty(value = "#{consultaBajaService}")
     private transient ConsultaBajaService consultaBajaService;
+
+    @ManagedProperty(value = "#{nuevaBajaService}")
+    private transient NuevaBajaService nuevaBajaService;
+
+    @ManagedProperty(value = "#{nuevaBajaUsuarioBean}")
+    private NuevaBajaUsuarioBean nuevaBajaUsuarioBean;
+
+    @ManagedProperty(value = "#{altasBajasUsuariosBean}")
+    private AltasBajasUsuariosBean altasBajasUsuariosBean;
 
     private String matricula;
     private String periodoSeleccionado;
@@ -99,6 +111,32 @@ public class ConsultaBajaUsuariosBean extends BaseBean {
         return valido;
     }
 
+    public void editar(ConsultaBajaDTO bajaSeleccionada) {
+        try {
+            nuevaBajaUsuarioBean.prepararEdicionDesdeConsulta(bajaSeleccionada);
+            altasBajasUsuariosBean.setPaginaActual("/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml");
+            altasBajasUsuariosBean.setMostrarOpcionesBajas(true);
+            RequestContext.getCurrentInstance().update(":frmAltasBajas:panelBotones");
+            RequestContext.getCurrentInstance().update(":frmAltasBajas:panelContenido");
+        } catch (Exception ex) {
+            LOGGER.error("Error al preparar edición de baja", ex);
+            agregarMsgError("No fue posible preparar la edición de la baja seleccionada.", null);
+        }
+    }
+
+    public void eliminar(ConsultaBajaDTO bajaSeleccionada) {
+        try {
+            nuevaBajaService.eliminarBaja(bajaSeleccionada);
+            agregarMsgInfo("Baja eliminada correctamente", null);
+            buscar();
+        } catch (IllegalArgumentException ex) {
+            agregarMsgError(ex.getMessage(), null);
+        } catch (Exception ex) {
+            LOGGER.error("Error al eliminar la baja", ex);
+            agregarMsgError("Ocurrió un error al eliminar la baja seleccionada.", null);
+        }
+    }
+
     public String getMatricula() {
         return matricula;
     }
@@ -145,5 +183,29 @@ public class ConsultaBajaUsuariosBean extends BaseBean {
 
     public void setConsultaBajaService(ConsultaBajaService consultaBajaService) {
         this.consultaBajaService = consultaBajaService;
+    }
+
+    public NuevaBajaService getNuevaBajaService() {
+        return nuevaBajaService;
+    }
+
+    public void setNuevaBajaService(NuevaBajaService nuevaBajaService) {
+        this.nuevaBajaService = nuevaBajaService;
+    }
+
+    public NuevaBajaUsuarioBean getNuevaBajaUsuarioBean() {
+        return nuevaBajaUsuarioBean;
+    }
+
+    public void setNuevaBajaUsuarioBean(NuevaBajaUsuarioBean nuevaBajaUsuarioBean) {
+        this.nuevaBajaUsuarioBean = nuevaBajaUsuarioBean;
+    }
+
+    public AltasBajasUsuariosBean getAltasBajasUsuariosBean() {
+        return altasBajasUsuariosBean;
+    }
+
+    public void setAltasBajasUsuariosBean(AltasBajasUsuariosBean altasBajasUsuariosBean) {
+        this.altasBajasUsuariosBean = altasBajasUsuariosBean;
     }
 }

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaBajaUsuarioBean.java
@@ -17,6 +17,7 @@ import org.primefaces.context.RequestContext;
 import mx.gob.sedesol.basegestor.commons.dto.NodoDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaMatriculaDetalleDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaSolicitudDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.PlanBajaDTO;
 import mx.gob.sedesol.basegestor.service.gestionescolar.NuevaBajaService;
 import mx.gob.sedesol.gestorweb.beans.acceso.BaseBean;
@@ -70,6 +71,9 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
     private boolean esTipoDefinitiva;
     private boolean esTipoTemporalOParcial;
     private boolean esSinAsignaturas;
+    private boolean modoEdicion;
+    private Long idBajaEdicion;
+    private Long idMotivoBajaEdicion;
 
     @ManagedProperty(value = "#{sistema}")
     private SistemaBean sistema;
@@ -184,7 +188,14 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
     public void registrarBaja() {
         try {
             BajaSolicitudDTO solicitud = construirSolicitud();
-            nuevaBajaService.aplicarBaja(solicitud);
+            if (modoEdicion) {
+                nuevaBajaService.actualizarBaja(idBajaEdicion, solicitud, idMotivoBajaEdicion);
+                modoEdicion = false;
+                idBajaEdicion = null;
+                idMotivoBajaEdicion = null;
+            } else {
+                nuevaBajaService.aplicarBaja(solicitud);
+            }
             mensajeExitoDialogo = sistema.obtenerTexto("gw.gestionescolar.altasbajas.nuevaBaja.mensaje.bajaAplicadaCorrectamente");
             limpiarFormulario();
             mostrarDialogo("dlgNuevaBajaExito");
@@ -202,6 +213,40 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
         RequestContext.getCurrentInstance().execute("PF('" + widgetVar + "').show()");
     }
 
+    public void prepararEdicionDesdeConsulta(ConsultaBajaDTO baja) {
+        limpiarFormulario();
+        modoEdicion = true;
+        idBajaEdicion = baja.getIdBaja() != null ? baja.getIdBaja().longValue() : null;
+        idMotivoBajaEdicion = baja.getIdMotivoBaja();
+
+        matriculaUsuario = baja.getMatricula();
+        nombreEstudiante = baja.getNombreEstudiante();
+        idTipoBaja = baja.getIdTipoBaja() != null ? baja.getIdTipoBaja().longValue() : null;
+        idPlan = baja.getIdPlan();
+        semestres = idPlan != null ? obtenerSemestres(idPlan) : Collections.emptyList();
+        idSemestre = baja.getIdSemestre();
+        bloques = idSemestre != null ? obtenerBloques(idSemestre) : Collections.emptyList();
+        idBloque = baja.getIdBloque();
+
+        Long idEjeCapacitacion = idBloque != null ? idBloque : idSemestre;
+        programas = idEjeCapacitacion != null
+                ? convertirANodosSelectItem(nuevaBajaService.obtenerProgramasPorEje(idEjeCapacitacion))
+                : Collections.emptyList();
+        idPrograma = baja.getIdPrograma();
+
+        idPeriodo = baja.getPeriodo();
+        actualizarEventos();
+        idEvento = baja.getIdEvento();
+
+        motivo = baja.getMotivo();
+        numeroSolicitud = baja.getNumeroSolicitud();
+        quienAplica = baja.getQuienAplica();
+
+        matriculaValida = true;
+        actualizarVisibilidadCampos();
+        actualizarHabilitacionSecuencial();
+    }
+
     public void limpiarFormulario() {
         matriculaUsuario = null;
         idTipoBaja = null;
@@ -216,6 +261,9 @@ public class NuevaBajaUsuarioBean extends BaseBean implements Serializable {
         esTipoDefinitiva = false;
         esTipoTemporalOParcial = false;
         esSinAsignaturas = false;
+        modoEdicion = false;
+        idBajaEdicion = null;
+        idMotivoBajaEdicion = null;
         mostrarSemestre = true;
         mostrarBloque = true;
         mostrarPrograma = true;


### PR DESCRIPTION
## Summary
- expand consulta de bajas data to expose identifiers and metadata required for editing and deletion
- add service logic to update existing bajas, reactivate enrollments on delete, and reuse NuevaBaja form for pending records
- surface edit/delete actions in the consulta UI with pending-only editing and success/error feedback

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e34a3bdc832fa53365524d0a0923)