### PR TITLE
Corrige edición de bajas para evitar reprocesamiento en Moodle

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/INuevaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/INuevaBajaRepository.java
@@ -8,6 +8,7 @@ import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaAplicacionDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaMatriculacionDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.DatosMoodlePersonaDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.PlanBajaDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
 
 public interface INuevaBajaRepository {
 
@@ -48,6 +49,8 @@ public interface INuevaBajaRepository {
     void insertarBaja(BajaAplicacionDTO bajaAplicacionDTO);
 
     BajaMatriculaDetalleDTO consultarDatosPorMatricula(String matricula);
+
+    ConsultaBajaDTO consultarBajaPorId(Long idBaja);
 
     void actualizarBaja(Long idBaja, BajaAplicacionDTO bajaAplicacionDTO);
 

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
@@ -10,9 +10,10 @@ import javax.persistence.Query;
 import org.springframework.stereotype.Repository;
 
 import mx.gob.sedesol.basegestor.commons.dto.NodoDTO;
-import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaMatriculaDetalleDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaAplicacionDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaMatriculaDetalleDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaMatriculacionDTO;
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.ConsultaBajaDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.DatosMoodlePersonaDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.PlanBajaDTO;
 import org.springframework.transaction.annotation.Transactional;
@@ -347,6 +348,78 @@ public class NuevaBajaRepository implements INuevaBajaRepository {
         dto.setIdPrograma(obtenerLong(fila[4]));
         dto.setPeriodo(obtenerCadena(fila[5]));
         dto.setIdEvento(obtenerLong(fila[6]));
+        return dto;
+    }
+
+    @Override
+    public ConsultaBajaDTO consultarBajaPorId(Long idBaja) {
+        String consulta = "SELECT rpb.id_baja AS id_baja, "
+                + " tp.sso_idUsuario AS matricula, "
+                + " CONCAT(tp.sso_nombre, ' ', tp.sso_apellidoPaterno, IF(tp.sso_apellidoMaterno != '', CONCAT(' ', tp.sso_apellidoMaterno),'')) AS nombre_estudiante, "
+                + " tpl.nombre AS plan, "
+                + " tfdp.nombre_tentativo AS programa, "
+                + " te.nombre_ec AS evento, "
+                + " ctb.nombre AS tipo_baja, "
+                + " CONCAT((SELECT tmc2.nombre FROM tbl_malla_curricular tmc2 WHERE tmc2.id = tmc.id_padre),' ', tmc.nombre) AS estructura, "
+                + " tpi.nombre_periodo AS periodo, "
+                + " rpb.contabilizar AS estatus, "
+                + " rpb.id_plan AS id_plan, "
+                + " rpb.id_programa AS id_programa, "
+                + " rpb.id_evento AS id_evento, "
+                + " tmc.id AS id_bloque, "
+                + " tmc.id_padre AS id_semestre, "
+                + " tp.id_persona AS id_persona, "
+                + " rpb.id_user_enrolments_lms AS id_user_enrolments_lms, "
+                + " ctb.id_tipo_baja AS id_tipo_baja, "
+                + " rmb.id_motivo_baja AS id_motivo_baja, "
+                + " rmb.descripcion AS motivo, "
+                + " rpb.solicitud AS numero_solicitud, "
+                + " rpb.usuario_modifico AS quien_aplica, "
+                + " rpb.id_grupo AS id_grupo "
+                + "FROM rel_persona_bajas rpb "
+                + " JOIN tbl_persona tp ON tp.id_persona = rpb.id_persona "
+                + " JOIN tbl_planes tpl ON tpl.id_plan = rpb.id_plan "
+                + " JOIN tbl_ficha_descriptiva_programa tfdp ON tfdp.id_programa = rpb.id_programa "
+                + " JOIN rel_motivo_baja rmb ON rmb.id_motivo_baja = rpb.motivo_baja_id "
+                + " JOIN cat_tipo_bajas ctb ON ctb.id_tipo_baja = rmb.tipo_baja_id "
+                + " JOIN tbl_malla_curricular tmc ON tmc.id = tfdp.id_eje_capacitacion "
+                + " LEFT JOIN tbl_eventos te ON te.id_evento = rpb.id_evento "
+                + " LEFT JOIN tbl_periodos_inscripcion tpi ON te.cve_evento_cap LIKE CONCAT('%', tpi.nombre_periodo, '%') "
+                + "WHERE rpb.id_baja = :idBaja";
+
+        Query query = entityManager.createNativeQuery(consulta);
+        query.setParameter("idBaja", idBaja);
+        List<Object[]> resultados = query.getResultList();
+
+        if (resultados.isEmpty()) {
+            return null;
+        }
+
+        Object[] registro = resultados.get(0);
+        ConsultaBajaDTO dto = new ConsultaBajaDTO();
+        dto.setIdBaja(registro[0] != null ? Integer.valueOf(registro[0].toString()) : null);
+        dto.setMatricula(registro[1] != null ? registro[1].toString() : "");
+        dto.setNombreEstudiante(registro[2] != null ? registro[2].toString() : "");
+        dto.setPlan(registro[3] != null ? registro[3].toString() : "");
+        dto.setPrograma(registro[4] != null ? registro[4].toString() : "");
+        dto.setEvento(registro[5] != null ? registro[5].toString() : "");
+        dto.setTipoBaja(registro[6] != null ? registro[6].toString() : "");
+        dto.setEstructura(registro[7] != null ? registro[7].toString() : "");
+        dto.setPeriodo(registro[8] != null ? registro[8].toString() : "");
+        dto.setEstatus(registro[9] != null ? Integer.valueOf(registro[9].toString()) : null);
+        dto.setIdPlan(registro[10] != null ? Long.valueOf(registro[10].toString()) : null);
+        dto.setIdPrograma(registro[11] != null ? Long.valueOf(registro[11].toString()) : null);
+        dto.setIdEvento(registro[12] != null ? Long.valueOf(registro[12].toString()) : null);
+        dto.setIdBloque(registro[13] != null ? Long.valueOf(registro[13].toString()) : null);
+        dto.setIdSemestre(registro[14] != null ? Long.valueOf(registro[14].toString()) : null);
+        dto.setIdPersona(registro[15] != null ? Long.valueOf(registro[15].toString()) : null);
+        dto.setIdUserEnrolmentsLms(registro[16] != null ? Integer.valueOf(registro[16].toString()) : null);
+        dto.setIdTipoBaja(registro[17] != null ? Integer.valueOf(registro[17].toString()) : null);
+        dto.setIdMotivoBaja(registro[18] != null ? Long.valueOf(registro[18].toString()) : null);
+        dto.setMotivo(registro[19] != null ? registro[19].toString() : "");
+        dto.setNumeroSolicitud(registro[20] != null ? registro[20].toString() : "");
+        dto.setQuienAplica(registro[21] != null ? registro[21].toString() : "");
+        dto.setIdGrupo(registro[22] != null ? Long.valueOf(registro[22].toString()) : null);
         return dto;
     }
 

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/gestionescolar/NuevaBajaServiceImpl.java
@@ -1,6 +1,7 @@
 package mx.gob.sedesol.basegestor.service.impl.gestionescolar;
 
 import java.util.List;
+import java.util.Objects;
 
 import mx.gob.sedesol.basegestor.commons.dto.NodoDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaMatriculaDetalleDTO;
@@ -86,7 +87,49 @@ public class NuevaBajaServiceImpl implements NuevaBajaService {
         if (idBaja == null) {
             throw new IllegalArgumentException("El identificador de la baja es obligatorio para actualizarla");
         }
-        procesarBaja(solicitud, idBaja, idMotivoBaja);
+        ConsultaBajaDTO bajaActual = nuevaBajaRepository.consultarBajaPorId(idBaja);
+        if (bajaActual == null) {
+            throw new IllegalArgumentException("No se encontró la baja a actualizar");
+        }
+
+        Long idTipoActual = bajaActual.getIdTipoBaja() != null ? bajaActual.getIdTipoBaja().longValue() : null;
+        Long idTipoSolicitud = solicitud.getIdTipoBaja() != null ? solicitud.getIdTipoBaja() : idTipoActual;
+        solicitud.setIdTipoBaja(idTipoSolicitud);
+
+        boolean cambioDeTipo = !Objects.equals(idTipoSolicitud, idTipoActual);
+
+        if (cambioDeTipo) {
+            procesarBaja(solicitud, idBaja, idMotivoBaja);
+            return;
+        }
+
+        Long idPersona = bajaActual.getIdPersona();
+        if (idPersona == null) {
+            throw new IllegalArgumentException("No se encontró la persona asociada a la baja");
+        }
+
+        Long motivoId = idMotivoBaja != null ? idMotivoBaja : bajaActual.getIdMotivoBaja();
+        if (motivoId == null) {
+            motivoId = nuevaBajaRepository.insertarMotivoBaja(solicitud.getIdTipoBaja(), solicitud.getMotivo());
+        } else {
+            nuevaBajaRepository.actualizarMotivoBaja(motivoId, solicitud.getIdTipoBaja(), solicitud.getMotivo());
+        }
+
+        Long procesoId = nuevaBajaRepository.obtenerIdProcesoBaja();
+        BajaAplicacionDTO bajaAplicacionDTO = new BajaAplicacionDTO(
+                idPersona,
+                motivoId,
+                procesoId,
+                bajaActual.getIdPlan(),
+                bajaActual.getIdPrograma(),
+                bajaActual.getIdEvento(),
+                bajaActual.getIdGrupo(),
+                bajaActual.getIdUserEnrolmentsLms(),
+                solicitud.getQuienAplica(),
+                bajaActual.getEstatus(),
+                solicitud.getNumeroSolicitud());
+
+        nuevaBajaRepository.actualizarBaja(idBaja, bajaAplicacionDTO);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- agrega consulta detallada de bajas para recuperar información previa al editar
- mantiene la relación Moodle e id_user_enrolments_lms al actualizar sin cambiar el tipo de baja
- evita reprocesar la lógica de suspensión cuando el tipo de baja permanece igual

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce97412d4832fbec00520196dfd8e)