### PR TITLE
Fix loading modal when canceling consulta de bajas edit

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/gestionescolar/NuevaBajaRepository.java
@@ -7,14 +7,10 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
 
+import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.*;
 import org.springframework.stereotype.Repository;
 
 import mx.gob.sedesol.basegestor.commons.dto.NodoDTO;
-import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaMatriculaDetalleDTO;
-import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaAplicacionDTO;
-import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.BajaMatriculacionDTO;
-import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.DatosMoodlePersonaDTO;
-import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.PlanBajaDTO;
 import org.springframework.transaction.annotation.Transactional;
 
 @Repository

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaBaja.xhtml
@@ -226,12 +226,6 @@
                     </div>
                 </p:panel>
 
-                <p:dialog modal="true" appendTo="@(body)" widgetVar="dialogLayout"
-                          header="Cargando" draggable="false" closable="false" resizable="false"
-                          style="text-align: center;" dynamic="true">
-                    <p:graphicImage library="images" name="ajax-loader.gif" />
-                </p:dialog>
-
                 <p:dialog appendTo="@(body)" draggable="false" position="center"
                           resizable="false" closable="false" modal="true" width="600px"
                           widgetVar="dlgNuevaBajaValidacion" header="Informativo" dynamic="true">


### PR DESCRIPTION
## Summary
- remove the duplicate loading dialog from the nueva baja view so it always relies on the global loader
- prevent the loading overlay from remaining visible after canceling an edit started from consultar baja

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695095288cf0832f83fd82260bffab92)