### PR TITLE
Corrige limpieza total de filtros en consulta de bajas

### DIFF
--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/ConsultaBajaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/ConsultaBajaUsuariosBean.java
@@ -84,6 +84,7 @@ public class ConsultaBajaUsuariosBean extends BaseBean {
         resultados = new ArrayList<>();
         limpiarComponentes("frmAltasBajas:frmConsultaBaja");
         RequestContext.getCurrentInstance().reset(":frmAltasBajas:frmResultadosBaja");
+        RequestContext.getCurrentInstance().update(":frmAltasBajas:frmConsultaBaja");
     }
 
     private void limpiarComponentes(String clientId) {

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/ConsultaBajaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/ConsultaBajaUsuariosBean.java
@@ -7,6 +7,9 @@ import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ManagedProperty;
 import javax.faces.bean.ViewScoped;
+import javax.faces.component.UIComponent;
+import javax.faces.component.UIInput;
+import javax.faces.context.FacesContext;
 
 import org.apache.log4j.Logger;
 import org.primefaces.context.RequestContext;
@@ -79,6 +82,32 @@ public class ConsultaBajaUsuariosBean extends BaseBean {
         periodoSeleccionado = null;
         estatusSeleccionado = null;
         resultados = new ArrayList<>();
+        limpiarComponentes("frmAltasBajas:frmConsultaBaja");
+        RequestContext.getCurrentInstance().reset(":frmAltasBajas:frmResultadosBaja");
+    }
+
+    private void limpiarComponentes(String clientId) {
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        if (facesContext == null) {
+            return;
+        }
+        UIComponent componente = facesContext.getViewRoot().findComponent(clientId);
+        if (componente != null) {
+            limpiarValores(componente);
+        }
+    }
+
+    private void limpiarValores(UIComponent componente) {
+        if (componente instanceof UIInput) {
+            UIInput input = (UIInput) componente;
+            input.setSubmittedValue(null);
+            input.setValue(null);
+            input.setLocalValueSet(false);
+            input.setValid(true);
+        }
+        for (UIComponent hijo : componente.getChildren()) {
+            limpiarValores(hijo);
+        }
     }
 
     public String obtenerNombreEstatus(Integer estatus) {


### PR DESCRIPTION
## Summary
- limpiar los valores locales de los controles de matrícula, periodo y estatus al usar el botón de limpieza
- mantener el reseteo de la tabla de resultados en la misma acción

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e4385208832fbe4fb8da175ea637)