### PR TITLE
Fix limpiar campos behavior in consulta de bajas

### DIFF
--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -77,13 +77,11 @@
                             <div class="col-md-12 text-right">
 
                                 <p:commandButton value="Limpiar campos"
-                                                 actionListener="#{consultaBajaUsuariosBean.limpiar}"
                                                  process="@this"
                                                  update=":frmAltasBajas:frmConsultaBaja :frmAltasBajas:frmResultadosBaja"
-                                                 resetValues="true"
-                                                 styleClass="btn btn-default">
-                                    <p:resetInput target=":frmAltasBajas:frmConsultaBaja :frmAltasBajas:frmResultadosBaja" />
-                                </p:commandButton>
+                                                 action="#{consultaBajaUsuariosBean.limpiar}"
+                                                 ajax="true"
+                                                 styleClass="btn btn-default" />
 
                                 <p:commandButton id="btnBuscarBajas"
                                                  process="@form"

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/consultaBaja.xhtml
@@ -78,10 +78,18 @@
 
                                 <p:commandButton value="Limpiar campos"
                                                  process="@this"
-                                                 update=":frmAltasBajas:frmConsultaBaja :frmAltasBajas:frmResultadosBaja"
                                                  action="#{consultaBajaUsuariosBean.limpiar}"
+                                                 update=":frmAltasBajas:frmConsultaBaja :frmAltasBajas:frmResultadosBaja"
                                                  ajax="true"
+                                                 immediate="true"
+                                                 resetValues="true"
+                                                 oncomplete="
+                                                   PF('widget_frmAltasBajas_frmConsultaBaja_periodo').selectValue('');
+                                                   PF('widget_frmAltasBajas_frmConsultaBaja_estatus').selectValue('');
+                                                   $('#frmAltasBajas\\:frmConsultaBaja\\:matricula').val('');
+                                                 "
                                                  styleClass="btn btn-default" />
+
 
                                 <p:commandButton id="btnBuscarBajas"
                                                  process="@form"


### PR DESCRIPTION
## Summary
- Actualiza el botón "Limpiar campos" en Consulta Bajas para usar el mismo patrón que otros formularios.

## Testing
- No se ejecutaron pruebas; cambio de interfaz únicamente.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695239ea75a4832fadad8556521b25b1)