### PR TITLE
Implementar importación de usuarios desde fuente externa

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/admin/IUsuariosImportarRepo.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/admin/IUsuariosImportarRepo.java
@@ -31,5 +31,6 @@ public interface IUsuariosImportarRepo {
 
 	boolean verificarRelacionConvocatoria(String planId, String convocatoriaId);
 
+	Object[] consultaDetalleFuenteExterna(Integer idFuenteExterna);
 	
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/admin/UsuariosImportarRepo.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/admin/UsuariosImportarRepo.java
@@ -238,5 +238,15 @@ public class UsuariosImportarRepo implements IUsuariosImportarRepo {
 	    return resultado == 1;
 	}
 
+	@Override
+	public Object[] consultaDetalleFuenteExterna(Integer idFuenteExterna) {
+		String consulta = "SELECT servidor, usuario, alias, nombre_base_datos, consulta FROM cat_fuentes_externas "
+				+ "WHERE id_fuente_externa = :idFuente AND activo = 1";
+		Query query = entityManager.createNativeQuery(consulta);
+		query.setParameter("idFuente", idFuenteExterna);
+		List<?> resultado = query.getResultList();
+		return resultado != null && !resultado.isEmpty() ? (Object[]) resultado.get(0) : null;
+	}
+
 
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/UsuariosImportarService.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/UsuariosImportarService.java
@@ -30,7 +30,8 @@ public interface UsuariosImportarService {
 	
 	List<PersonaSigeDTO> consultaPersonasImportar(String fuenteExterna, String convocatoria);
 
+	Object[] consultaDetalleFuenteExterna(Integer idFuenteExterna);
+
 
 }
-
 

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaServiceFacade.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaServiceFacade.java
@@ -188,6 +188,10 @@ public class PersonaServiceFacade {
 	public List<PersonaSigeDTO> consultaPersonasImportar(String fuenteExterna, String convocatoria) {
 		return usuariosImportarService.consultaPersonasImportar(fuenteExterna, convocatoria);
 	}
+	
+	public Object[] consultaDetalleFuenteExterna(Integer idFuenteExterna) {
+		return usuariosImportarService.consultaDetalleFuenteExterna(idFuenteExterna);
+	}
 
 	public String obtenerRutaAlmacenamientoFotosUsuario() {
 		StringBuilder rutaAlmacenamiento = new StringBuilder(

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
@@ -12,6 +12,9 @@ import org.springframework.stereotype.Service;
 
 import mx.gob.sedesol.basegestor.commons.dto.admin.PersonaSigeDTO;
 import mx.gob.sedesol.basegestor.commons.dto.admin.ResultadoDTO;
+import mx.gob.sedesol.basegestor.commons.utils.MensajesSistemaEnum;
+import mx.gob.sedesol.basegestor.commons.utils.ObjectUtils;
+import mx.gob.sedesol.basegestor.commons.utils.ResultadoTransaccionEnum;
 import mx.gob.sedesol.basegestor.model.entities.admin.TblPersonaSige;
 import mx.gob.sedesol.basegestor.model.repositories.admin.PersonaSigeRepo;
 import mx.gob.sedesol.basegestor.service.admin.ComunValidacionService;
@@ -55,38 +58,85 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 	}
 	@Override
 	public PersonaSigeDTO buscarPorId(Long id) {
-		// TODO Auto-generated method stub
-		return null;
+		if (ObjectUtils.isNull(id)) {
+			return null;
+		}
+		return personaSigeRepo.findById(id).map(persona -> mapper.map(persona, PersonaSigeDTO.class)).orElse(null);
 	}
 	@Override
 	public ResultadoDTO<PersonaSigeDTO> guardar(PersonaSigeDTO dto) {
-		// TODO Auto-generated method stub
-		return null;
+		ResultadoDTO<PersonaSigeDTO> resultado = new ResultadoDTO<>();
+		try {
+			validarPersistencia(dto, resultado);
+			if (!resultado.esCorrecto()) {
+				return resultado;
+			}
+			TblPersonaSige entidad = mapper.map(dto, TblPersonaSige.class);
+			entidad = personaSigeRepo.save(entidad);
+			resultado.setDto(mapper.map(entidad, PersonaSigeDTO.class));
+			resultado.setMensaje(MensajesSistemaEnum.ADMIN_MSG_REGISTRO_EXITOSO.getId());
+			resultado.setResultado(ResultadoTransaccionEnum.EXITOSO);
+		} catch (Exception ex) {
+			logger.error(ex.getMessage(), ex);
+			resultado.setMensajeError(MensajesSistemaEnum.MSG_ERROR_INTERNO, " " + ex.getMessage());
+		}
+		return resultado;
 	}
 	@Override
 	public ResultadoDTO<PersonaSigeDTO> actualizar(PersonaSigeDTO dto) {
-		// TODO Auto-generated method stub
-		return null;
+		ResultadoDTO<PersonaSigeDTO> resultado = new ResultadoDTO<>();
+		try {
+			validarActualizacion(dto, resultado);
+			if (!resultado.esCorrecto()) {
+				return resultado;
+			}
+			TblPersonaSige entidad = mapper.map(dto, TblPersonaSige.class);
+			entidad = personaSigeRepo.save(entidad);
+			resultado.setDto(mapper.map(entidad, PersonaSigeDTO.class));
+			resultado.setMensaje(MensajesSistemaEnum.ADMIN_MSG_REGISTRO_EXITOSO.getId());
+			resultado.setResultado(ResultadoTransaccionEnum.EXITOSO);
+		} catch (Exception ex) {
+			logger.error(ex.getMessage(), ex);
+			resultado.setMensajeError(MensajesSistemaEnum.MSG_ERROR_INTERNO, " " + ex.getMessage());
+		}
+		return resultado;
 	}
 	@Override
 	public ResultadoDTO<PersonaSigeDTO> eliminar(PersonaSigeDTO dto) {
-		// TODO Auto-generated method stub
-		return null;
+		ResultadoDTO<PersonaSigeDTO> resultado = new ResultadoDTO<>();
+		try {
+			validarEliminacion(dto, resultado);
+			if (!resultado.esCorrecto()) {
+				return resultado;
+			}
+			if (!ObjectUtils.isNull(dto.getIdPersonaSige())) {
+				personaSigeRepo.deleteById(dto.getIdPersonaSige());
+			}
+			resultado.setResultado(ResultadoTransaccionEnum.EXITOSO);
+			resultado.setMensaje(MensajesSistemaEnum.ADMIN_MSG_REGISTRO_EXITOSO.getId());
+		} catch (Exception ex) {
+			logger.error(ex.getMessage(), ex);
+			resultado.setMensajeError(MensajesSistemaEnum.MSG_ERROR_INTERNO, " " + ex.getMessage());
+		}
+		return resultado;
 	}
 	@Override
 	public void validarPersistencia(PersonaSigeDTO dto, ResultadoDTO<PersonaSigeDTO> resultado) {
-		// TODO Auto-generated method stub
-		
+		if (ObjectUtils.isNull(dto)) {
+			resultado.setMensajeError(MensajesSistemaEnum.MSG_ERROR_INTERNO, " DTO nulo");
+		}
 	}
 	@Override
 	public void validarActualizacion(PersonaSigeDTO dto, ResultadoDTO<PersonaSigeDTO> resultado) {
-		// TODO Auto-generated method stub
-		
+		if (ObjectUtils.isNull(dto) || ObjectUtils.isNull(dto.getIdPersonaSige())) {
+			resultado.setMensajeError(MensajesSistemaEnum.MSG_ERROR_INTERNO, " DTO nulo o sin identificador");
+		}
 	}
 	@Override
 	public void validarEliminacion(PersonaSigeDTO dto, ResultadoDTO<PersonaSigeDTO> resultado) {
-		// TODO Auto-generated method stub
-		
+		if (ObjectUtils.isNull(dto) || ObjectUtils.isNull(dto.getIdPersonaSige())) {
+			resultado.setMensajeError(MensajesSistemaEnum.MSG_ERROR_INTERNO, " DTO nulo o sin identificador");
+		}
 	}
 	public PersonaSigeRepo getPersonaSigeRepo() {
 		return personaSigeRepo;

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/UsuariosImportarServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/UsuariosImportarServiceImpl.java
@@ -85,5 +85,10 @@ public class UsuariosImportarServiceImpl implements UsuariosImportarService{
 		return usuariosImportarRepo.consultaPersonasImportar(fuenteExterna, convocatoria);
 	}
 
+	@Override
+	public Object[] consultaDetalleFuenteExterna(Integer idFuenteExterna) {
+		return usuariosImportarRepo.consultaDetalleFuenteExterna(idFuenteExterna);
+	}
+
 
 }

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
@@ -5,6 +5,11 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
@@ -17,13 +22,16 @@ import org.primefaces.context.RequestContext;
 import mx.gob.sedesol.basegestor.commons.constantes.ConstantesGestor;
 import mx.gob.sedesol.basegestor.commons.dto.admin.ParametroWSMoodleDTO;
 import mx.gob.sedesol.basegestor.commons.dto.admin.PersonaDTO;
+import mx.gob.sedesol.basegestor.commons.dto.admin.PersonaSigeDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.EventoCapacitacionDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.GrupoDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.RelGrupoParticipanteDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.SelectImportarDTO;
 import mx.gob.sedesol.basegestor.commons.utils.ObjectUtils;
+import mx.gob.sedesol.basegestor.commons.dto.admin.ResultadoDTO;
 import mx.gob.sedesol.basegestor.service.impl.admin.PersonaServiceFacade;
 import mx.gob.sedesol.basegestor.service.impl.gestionescolar.EventoCapacitacionServiceFacade;
+import mx.gob.sedesol.basegestor.service.admin.PersonaSigeService;
 import mx.gob.sedesol.gestorweb.beans.acceso.BaseBean;
 
 @ManagedBean
@@ -37,6 +45,9 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
     @ManagedProperty("#{eventoCapacitacionServiceFacade}")
     private transient EventoCapacitacionServiceFacade eventoCapacitacionServiceFacade;
+    
+    @ManagedProperty("#{personaSigeService}")
+    private transient PersonaSigeService personaSigeService;
 
     private static final Logger LOGGER = Logger.getLogger(NuevaAltaUsuariosBean.class);
 
@@ -221,6 +232,45 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
         LOGGER.info("Alta registrada correctamente");
         mostrarDialogoExito("Alta aplicada correctamente");
         limpiarFormulario();
+    }
+    
+    public void importarDesdeFuenteExterna() {
+        try {
+            if (esVacio(matriculaNuevaAlta) || esVacio(fuenteExternaSeleccionada)) {
+                mostrarDialogoError("Configurar correctamente los datos de la fuente externa");
+                return;
+            }
+            Integer idFuente = parseEntero(fuenteExternaSeleccionada);
+            Object[] detalleFuente = personaServiceFacade.consultaDetalleFuenteExterna(idFuente);
+            if (detalleFuente == null || detalleFuente.length < 5) {
+                mostrarDialogoError("Configurar correctamente los datos de la fuente externa");
+                return;
+            }
+
+            String servidor = toString(detalleFuente[0]);
+            String usuario = toString(detalleFuente[1]);
+            String alias = toString(detalleFuente[2]);
+            String nombreBase = toString(detalleFuente[3]);
+            String consulta = toString(detalleFuente[4]);
+
+            if (consulta == null || !consulta.contains("?")) {
+                mostrarDialogoError("Configurar correctamente los datos de la fuente externa");
+                return;
+            }
+
+            PersonaSigeDTO personaSigeDTO = ejecutarConsultaFuente(servidor, usuario, alias, nombreBase, consulta,
+                    matriculaNuevaAlta.trim());
+            ResultadoDTO<PersonaSigeDTO> resultado = personaSigeService.guardar(personaSigeDTO);
+
+            if (resultado.esCorrecto()) {
+                mostrarDialogoExito("Información importada correctamente");
+            } else {
+                mostrarDialogoError(obtenerMensajeError(resultado, "No fue posible guardar la información"));
+            }
+        } catch (Exception ex) {
+            LOGGER.error(ex.getMessage(), ex);
+            mostrarDialogoError(ex.getMessage());
+        }
     }
 
     private ParametroWSMoodleDTO obtenerParametrosMoodle(EventoCapacitacionDTO evento) {
@@ -443,6 +493,10 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
             EventoCapacitacionServiceFacade eventoCapacitacionServiceFacade) {
         this.eventoCapacitacionServiceFacade = eventoCapacitacionServiceFacade;
     }
+    
+    public void setPersonaSigeService(PersonaSigeService personaSigeService) {
+        this.personaSigeService = personaSigeService;
+    }
 
     private void mostrarDialogo(String widgetVar) {
         RequestContext.getCurrentInstance().execute("PF('" + widgetVar + "').show()");
@@ -456,6 +510,53 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
     private void mostrarDialogoExito(String mensaje) {
         mensajeExitoDialogo = mensaje;
         mostrarDialogo("dlgNuevaAltaExito");
+    }
+    
+    private PersonaSigeDTO ejecutarConsultaFuente(String servidor, String usuario, String alias, String nombreBase,
+            String consulta, String matricula) throws SQLException {
+        String url = "jdbc:mysql://" + servidor + "/" + nombreBase;
+        try (Connection connection = DriverManager.getConnection(url, usuario, alias);
+                PreparedStatement statement = connection.prepareStatement(consulta)) {
+            statement.setString(1, matricula);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (!rs.next()) {
+                    throw new SQLException("No se encontró información en la fuente externa");
+                }
+                return mapearPersonaSige(rs);
+            }
+        }
+    }
+
+    private PersonaSigeDTO mapearPersonaSige(ResultSet rs) throws SQLException {
+        PersonaSigeDTO dto = new PersonaSigeDTO();
+        dto.setMatricula(rs.getString("matricula_sige"));
+        dto.setPassword(rs.getString("password_sige"));
+        dto.setNombre(rs.getString("nombre_sige"));
+        dto.setApellidoPaterno(rs.getString("apellidop_sige"));
+        dto.setApellidoMaterno(rs.getString("apellidom_sige"));
+        dto.setProgramaEducativo(rs.getString("programa_educativo_sige"));
+        dto.setDivision(rs.getString("division_sige"));
+        dto.setCorreoInstitucional(rs.getString("correo_institucional_sige"));
+        dto.setFechaNacimiento(rs.getDate("fecha_nacimiento_sige"));
+        dto.setCurp(rs.getString("curp_sige"));
+        dto.setNivelSige(rs.getString("nivel_sige"));
+        dto.setPersonaIdSige(rs.getInt("persona_id_sige"));
+        dto.setPerfilIdSige(rs.getInt("perfil_id_sige"));
+        return dto;
+    }
+
+    private String obtenerMensajeError(ResultadoDTO<PersonaSigeDTO> resultado, String mensajePorDefecto) {
+        if (!ObjectUtils.isNullOrEmpty(resultado.getMensajes())) {
+            return resultado.getMensajes().get(0);
+        }
+        if (resultado.getMensaje() != null) {
+            return resultado.getMensaje();
+        }
+        return mensajePorDefecto;
+    }
+
+    private String toString(Object valor) {
+        return valor != null ? valor.toString() : null;
     }
 
 }


### PR DESCRIPTION
## Summary
- Add repository and service support to retrieve full external source details for imports
- Enable PersonaSige service persistence to store imported SIGE records
- Implement NuevaAltaUsuariosBean flow to query external sources by matrícula and insert data into tbl_persona_sige

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69569d3223bc832f97defe9f150f15b3)