### PR TITLE
Refactor external import flow architecture

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/admin/PersonaSigeService.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/admin/PersonaSigeService.java
@@ -3,8 +3,11 @@ package mx.gob.sedesol.basegestor.service.admin;
 import java.util.List;
 
 import mx.gob.sedesol.basegestor.commons.dto.admin.PersonaSigeDTO;
+import mx.gob.sedesol.basegestor.model.entities.admin.TblPersonaSige;
 
 public interface PersonaSigeService extends CommonService<PersonaSigeDTO, Long>{
 	
 	List<PersonaSigeDTO> buscarNoRegistrados();
+
+	TblPersonaSige importarDesdeFuenteExterna(String idFuenteExterna, String matricula) throws Exception;
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaServiceFacade.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaServiceFacade.java
@@ -20,6 +20,7 @@ import mx.gob.sedesol.basegestor.commons.dto.admin.ResultadoDTO;
 import mx.gob.sedesol.basegestor.commons.dto.admin.RolDTO;
 import mx.gob.sedesol.basegestor.commons.dto.admin.TipoDiscapacidadDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.SelectImportarDTO;
+import mx.gob.sedesol.basegestor.model.entities.admin.TblPersonaSige;
 import mx.gob.sedesol.basegestor.service.ParametroSistemaService;
 import mx.gob.sedesol.basegestor.service.admin.AsentamientoService;
 import mx.gob.sedesol.basegestor.service.admin.DiscapacidadService;
@@ -31,6 +32,7 @@ import mx.gob.sedesol.basegestor.service.admin.PersonaCorreoService;
 import mx.gob.sedesol.basegestor.service.admin.PersonaRolesService;
 import mx.gob.sedesol.basegestor.service.admin.PersonaService;
 import mx.gob.sedesol.basegestor.service.admin.PersonaTelefonoService;
+import mx.gob.sedesol.basegestor.service.admin.PersonaSigeService;
 import mx.gob.sedesol.basegestor.service.admin.RoleService;
 import mx.gob.sedesol.basegestor.service.admin.UsuarioDatosLaboralesService;
 import mx.gob.sedesol.basegestor.service.gestionescolar.UsuariosImportarService;
@@ -79,6 +81,9 @@ public class PersonaServiceFacade {
 	
 	@Autowired
 	private UsuariosImportarService usuariosImportarService;
+
+	@Autowired
+	private PersonaSigeService personaSigeService;
 
 	
 	public List<PaisDTO> obtenerPaises() {
@@ -187,6 +192,10 @@ public class PersonaServiceFacade {
 	
 	public List<PersonaSigeDTO> consultaPersonasImportar(String fuenteExterna, String convocatoria) {
 		return usuariosImportarService.consultaPersonasImportar(fuenteExterna, convocatoria);
+	}
+
+	public TblPersonaSige importarPersonaSigeDesdeFuente(String idFuenteExterna, String matricula) throws Exception {
+		return personaSigeService.importarDesdeFuenteExterna(idFuenteExterna, matricula);
 	}
 
 	public String obtenerRutaAlmacenamientoFotosUsuario() {

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
@@ -1,14 +1,25 @@
 package mx.gob.sedesol.basegestor.service.impl.admin;
 
 import java.lang.reflect.Type;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 import org.apache.log4j.Logger;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
 
 import mx.gob.sedesol.basegestor.commons.dto.admin.PersonaSigeDTO;
 import mx.gob.sedesol.basegestor.commons.dto.admin.ResultadoDTO;
@@ -121,6 +132,120 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 		}
 		
 		return listaPersonas;
+	}
+
+	@Override
+	public TblPersonaSige importarDesdeFuenteExterna(String idFuenteExterna, String matricula) throws Exception {
+		Map<String, Object> configuracion = obtenerConfiguracionFuente(idFuenteExterna);
+		String consulta = (String) configuracion.get("consulta");
+
+		if (consulta == null || (!consulta.contains("?") && !consulta.toLowerCase().contains(":matricula")
+				&& !consulta.toLowerCase().contains(":usuario"))) {
+			throw new IllegalStateException("Configurar correctamente los datos de la fuente externa");
+		}
+
+		String servidor = (String) configuracion.get("servidor");
+		String usuario = (String) configuracion.get("usuario");
+		String password = (String) configuracion.get("alias");
+		String baseDatos = (String) configuracion.get("nombre_base_datos");
+
+		TblPersonaSige personaSige;
+		try (Connection connection = obtenerConexionExterna(servidor, baseDatos, usuario, password);
+				PreparedStatement statement = connection.prepareStatement(consulta)) {
+			statement.setString(1, matricula);
+			try (ResultSet rs = statement.executeQuery()) {
+				if (!rs.next()) {
+					throw new SQLException("No se encontraron resultados para la matrícula proporcionada");
+				}
+				personaSige = mapearPersonaSige(rs);
+			}
+		}
+
+		return personaSigeRepo.saveAndFlush(personaSige);
+	}
+
+	private Map<String, Object> obtenerConfiguracionFuente(String idFuenteExterna) throws SQLException, NamingException {
+		String sql = "SELECT servidor, usuario, alias, nombre_base_datos, consulta FROM cat_fuentes_externas WHERE id_fuente_externa = ?";
+		Map<String, Object> configuracion = new HashMap<>();
+		try (Connection connection = obtenerConexionGestor();
+				PreparedStatement statement = connection.prepareStatement(sql)) {
+			statement.setString(1, idFuenteExterna);
+			try (ResultSet rs = statement.executeQuery()) {
+				if (!rs.next()) {
+					throw new SQLException("No se encontró la configuración de la fuente externa seleccionada");
+				}
+				configuracion.put("servidor", rs.getString("servidor"));
+				configuracion.put("usuario", rs.getString("usuario"));
+				configuracion.put("alias", rs.getString("alias"));
+				configuracion.put("nombre_base_datos", rs.getString("nombre_base_datos"));
+				configuracion.put("consulta", rs.getString("consulta"));
+			}
+		}
+		return configuracion;
+	}
+
+	private TblPersonaSige mapearPersonaSige(ResultSet rs) throws SQLException {
+		TblPersonaSige personaSige = new TblPersonaSige();
+		personaSige.setMatricula(obtenerColumna(rs, "matricula_sige", "matricula"));
+		personaSige.setPassword(obtenerColumna(rs, "password_sige", "password"));
+		personaSige.setNombre(obtenerColumna(rs, "nombre_sige", "nombre"));
+		personaSige.setApellidoPaterno(obtenerColumna(rs, "apellidop_sige", "apellido_paterno"));
+		personaSige.setApellidoMaterno(obtenerColumna(rs, "apellidom_sige", "apellido_materno"));
+		personaSige.setProgramaEducativo(obtenerColumna(rs, "programa_educativo_sige", "programa_educativo"));
+		personaSige.setDivision(obtenerColumna(rs, "division_sige", "division"));
+		personaSige.setCorreoInstitucional(
+				obtenerColumna(rs, "correo_institucional_sige", "correo_institucional"));
+		personaSige.setFechaNacimiento(obtenerFecha(rs, "fecha_nacimiento_sige", "fecha_nacimiento"));
+		personaSige.setCurp(obtenerColumna(rs, "curp_sige", "curp"));
+		personaSige.setNivelSige(obtenerColumna(rs, "nivel_sige", "nivel"));
+		personaSige.setPersonaIdSige(obtenerEntero(rs, "persona_id_sige"));
+		personaSige.setPerfilIdSige(obtenerEntero(rs, "perfil_id_sige"));
+		return personaSige;
+	}
+
+	private int obtenerEntero(ResultSet rs, String columna) {
+		try {
+			return rs.getInt(columna);
+		} catch (SQLException e) {
+			return 0;
+		}
+	}
+
+	private String obtenerColumna(ResultSet rs, String... columnas) {
+		for (String columna : columnas) {
+			try {
+				String valor = rs.getString(columna);
+				if (valor != null) {
+					return valor;
+				}
+			} catch (SQLException e) {
+				// Ignorar y probar con la siguiente columna
+			}
+		}
+		return null;
+	}
+
+	private java.util.Date obtenerFecha(ResultSet rs, String... columnas) {
+		for (String columna : columnas) {
+			try {
+				return rs.getDate(columna);
+			} catch (SQLException e) {
+				// Ignorar y probar con la siguiente columna
+			}
+		}
+		return null;
+	}
+
+	private Connection obtenerConexionGestor() throws NamingException, SQLException {
+		InitialContext ctx = new InitialContext();
+		DataSource ds = (DataSource) ctx.lookup("java:jboss/jdbc_elearning");
+		return ds.getConnection();
+	}
+
+	private Connection obtenerConexionExterna(String servidor, String baseDatos, String usuario, String password)
+			throws SQLException {
+		String url = String.format("jdbc:mysql://%s/%s", servidor, baseDatos);
+		return DriverManager.getConnection(url, usuario, password);
 	}
 	
 }

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml
@@ -25,7 +25,8 @@
                                                styleClass="requerido bloque" />
                                 <p:inputText id="txtMatriculaImportar"
                                              styleClass="form-control"
-                                             style="width: 100%;" />
+                                             style="width: 100%;"
+                                             value="#{nuevaAltaUsuariosBean.matriculaNuevaAlta}" />
                             </div>
                             <div class="col-md-6 col-sm-6 col-xs-12">
                                 <p:outputLabel for="somFuenteExterna"
@@ -47,7 +48,9 @@
                     <div class="row" style="margin-top: 20px;">
                         <div class="col-md-12 text-right">
                             <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.btn.importar')}"
-                                             type="button"
+                                             action="#{nuevaAltaUsuariosBean.importarDesdeFuenteExterna}"
+                                             update="@form"
+                                             process="@form"
                                              styleClass="btn btn-primary" />
                         </div>
                     </div>

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
@@ -458,4 +458,21 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
         mostrarDialogo("dlgNuevaAltaExito");
     }
 
+    public void importarDesdeFuenteExterna() {
+        try {
+            if (ObjectUtils.isNull(fuenteExternaSeleccionada) || esVacio(fuenteExternaSeleccionada)) {
+                throw new IllegalArgumentException("Se requiere seleccionar una fuente externa.");
+            }
+            if (esVacio(matriculaNuevaAlta)) {
+                throw new IllegalArgumentException("La matrícula es obligatoria.");
+            }
+
+            personaServiceFacade.importarPersonaSigeDesdeFuente(fuenteExternaSeleccionada,
+                    matriculaNuevaAlta.trim());
+            mostrarDialogoExito("Información importada correctamente");
+        } catch (Exception e) {
+            LOGGER.error("Error al importar desde fuente externa", e);
+            mostrarDialogoError(e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- move external import JDBC, query, and mapping logic into PersonaSigeServiceImpl and expose via PersonaServiceFacade
- keep NuevaAltaUsuariosBean as orchestration-only, delegating to the facade while preserving existing validation and messaging

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69580bd033fc832f97766ae5db03a4e0)