### PR TITLE
Implement external import for nueva alta

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/admin/FuenteExternaDTO.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/admin/FuenteExternaDTO.java
@@ -1,0 +1,72 @@
+package mx.gob.sedesol.basegestor.commons.dto.admin;
+
+import java.io.Serializable;
+
+public class FuenteExternaDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Integer id;
+    private String nombre;
+    private String servidor;
+    private String usuario;
+    private String alias;
+    private String nombreBaseDatos;
+    private String consulta;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getServidor() {
+        return servidor;
+    }
+
+    public void setServidor(String servidor) {
+        this.servidor = servidor;
+    }
+
+    public String getUsuario() {
+        return usuario;
+    }
+
+    public void setUsuario(String usuario) {
+        this.usuario = usuario;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    public String getNombreBaseDatos() {
+        return nombreBaseDatos;
+    }
+
+    public void setNombreBaseDatos(String nombreBaseDatos) {
+        this.nombreBaseDatos = nombreBaseDatos;
+    }
+
+    public String getConsulta() {
+        return consulta;
+    }
+
+    public void setConsulta(String consulta) {
+        this.consulta = consulta;
+    }
+}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/admin/FuenteExternaDTO.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/commons/dto/admin/FuenteExternaDTO.java
@@ -10,6 +10,7 @@ public class FuenteExternaDTO implements Serializable {
     private String nombre;
     private String servidor;
     private String usuario;
+    private String contrasena;
     private String alias;
     private String nombreBaseDatos;
     private String consulta;
@@ -44,6 +45,14 @@ public class FuenteExternaDTO implements Serializable {
 
     public void setUsuario(String usuario) {
         this.usuario = usuario;
+    }
+
+    public String getContrasena() {
+        return contrasena;
+    }
+
+    public void setContrasena(String contrasena) {
+        this.contrasena = contrasena;
     }
 
     public String getAlias() {

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/admin/IUsuariosImportarRepo.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/admin/IUsuariosImportarRepo.java
@@ -3,6 +3,7 @@ package mx.gob.sedesol.basegestor.model.repositories.admin;
 import java.util.List;
 
 import mx.gob.sedesol.basegestor.commons.dto.admin.PersonaSigeDTO;
+import mx.gob.sedesol.basegestor.commons.dto.admin.FuenteExternaDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.SelectImportarDTO;
 
 public interface IUsuariosImportarRepo { 
@@ -10,6 +11,8 @@ public interface IUsuariosImportarRepo {
 	List<SelectImportarDTO> consultaConvocatorias();
 
 	List<SelectImportarDTO> consultaFuenteExterna();
+
+	FuenteExternaDTO buscarFuenteExternaPorId(Integer idFuente);
 
 	List<SelectImportarDTO> consultaPlanesActivos();
 

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/admin/PersonaSigeRepo.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/admin/PersonaSigeRepo.java
@@ -15,5 +15,7 @@ public interface PersonaSigeRepo extends JpaRepository<TblPersonaSige, Long> {
 	@Query(value = "SELECT t.* FROM tbl_persona_sige t JOIN (SELECT MAX(id_persona_sige) AS id_persona_sige FROM tbl_persona_sige WHERE curp_sige NOT IN (SELECT sso_curp FROM tbl_persona) AND (correo_institucional_sige != \"\" OR correo_institucional_sige IS NULL) GROUP BY correo_institucional_sige) AS subquery ON t.id_persona_sige = subquery.id_persona_sige", nativeQuery = true)
     List<TblPersonaSige> obtenetPersonasNoRegistradas();
 
+	TblPersonaSige findByMatricula(String matricula);
+
 	
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/admin/UsuariosImportarRepo.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/admin/UsuariosImportarRepo.java
@@ -72,7 +72,7 @@ public class UsuariosImportarRepo implements IUsuariosImportarRepo {
 
 	@Override
 	public FuenteExternaDTO buscarFuenteExternaPorId(Integer idFuente) {
-		String consulta = "SELECT id_fuente_externa, nombre, servidor, usuario, alias, nombre_base_datos, consulta "
+		String consulta = "SELECT id_fuente_externa, nombre, servidor, usuario, contrasena, alias, nombre_base_datos, consulta "
 				+ "FROM cat_fuentes_externas WHERE activo = 1 AND id_fuente_externa = :idFuente";
 		Query query = entityManager.createNativeQuery(consulta);
 		query.setParameter("idFuente", idFuente);
@@ -86,9 +86,10 @@ public class UsuariosImportarRepo implements IUsuariosImportarRepo {
 		dto.setNombre(fila[1] != null ? fila[1].toString() : null);
 		dto.setServidor(fila[2] != null ? fila[2].toString() : null);
 		dto.setUsuario(fila[3] != null ? fila[3].toString() : null);
-		dto.setAlias(fila[4] != null ? fila[4].toString() : null);
-		dto.setNombreBaseDatos(fila[5] != null ? fila[5].toString() : null);
-		dto.setConsulta(fila[6] != null ? fila[6].toString() : null);
+		dto.setContrasena(fila[4] != null ? fila[4].toString() : null);
+		dto.setAlias(fila[5] != null ? fila[5].toString() : null);
+		dto.setNombreBaseDatos(fila[6] != null ? fila[6].toString() : null);
+		dto.setConsulta(fila[7] != null ? fila[7].toString() : null);
 		return dto;
 	}
 

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/admin/UsuariosImportarRepo.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/model/repositories/admin/UsuariosImportarRepo.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import mx.gob.sedesol.basegestor.commons.dto.admin.FuenteExternaDTO;
 import mx.gob.sedesol.basegestor.commons.dto.admin.PersonaSigeDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.SelectImportarDTO;
 
@@ -67,6 +68,28 @@ public class UsuariosImportarRepo implements IUsuariosImportarRepo {
 			}
 		}
 		return regresa;
+	}
+
+	@Override
+	public FuenteExternaDTO buscarFuenteExternaPorId(Integer idFuente) {
+		String consulta = "SELECT id_fuente_externa, nombre, servidor, usuario, alias, nombre_base_datos, consulta "
+				+ "FROM cat_fuentes_externas WHERE activo = 1 AND id_fuente_externa = :idFuente";
+		Query query = entityManager.createNativeQuery(consulta);
+		query.setParameter("idFuente", idFuente);
+		List<Object[]> resultado = query.getResultList();
+		if (resultado.isEmpty()) {
+			return null;
+		}
+		Object[] fila = resultado.get(0);
+		FuenteExternaDTO dto = new FuenteExternaDTO();
+		dto.setId(fila[0] != null ? Integer.parseInt(fila[0].toString()) : null);
+		dto.setNombre(fila[1] != null ? fila[1].toString() : null);
+		dto.setServidor(fila[2] != null ? fila[2].toString() : null);
+		dto.setUsuario(fila[3] != null ? fila[3].toString() : null);
+		dto.setAlias(fila[4] != null ? fila[4].toString() : null);
+		dto.setNombreBaseDatos(fila[5] != null ? fila[5].toString() : null);
+		dto.setConsulta(fila[6] != null ? fila[6].toString() : null);
+		return dto;
 	}
 
 	@Override

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/admin/PersonaSigeService.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/admin/PersonaSigeService.java
@@ -7,4 +7,6 @@ import mx.gob.sedesol.basegestor.commons.dto.admin.PersonaSigeDTO;
 public interface PersonaSigeService extends CommonService<PersonaSigeDTO, Long>{
 	
 	List<PersonaSigeDTO> buscarNoRegistrados();
+
+	PersonaSigeDTO buscarPorMatricula(String matricula);
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/UsuariosImportarService.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/gestionescolar/UsuariosImportarService.java
@@ -3,6 +3,7 @@ package mx.gob.sedesol.basegestor.service.gestionescolar;
 import java.util.List;
 
 import mx.gob.sedesol.basegestor.commons.dto.admin.PersonaSigeDTO;
+import mx.gob.sedesol.basegestor.commons.dto.admin.FuenteExternaDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.SelectImportarDTO;
 
 
@@ -13,6 +14,8 @@ public interface UsuariosImportarService {
 	List<SelectImportarDTO> consultaConvocatorias();
 
 	List<SelectImportarDTO> consultaFuenteExterna();
+
+	FuenteExternaDTO buscarFuenteExternaPorId(Integer idFuente);
 
 	List<SelectImportarDTO> consultaPlanesActivos();
 
@@ -32,5 +35,4 @@ public interface UsuariosImportarService {
 
 
 }
-
 

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaServiceFacade.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaServiceFacade.java
@@ -19,6 +19,7 @@ import mx.gob.sedesol.basegestor.commons.dto.admin.PersonaSigeDTO;
 import mx.gob.sedesol.basegestor.commons.dto.admin.ResultadoDTO;
 import mx.gob.sedesol.basegestor.commons.dto.admin.RolDTO;
 import mx.gob.sedesol.basegestor.commons.dto.admin.TipoDiscapacidadDTO;
+import mx.gob.sedesol.basegestor.commons.dto.admin.FuenteExternaDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.SelectImportarDTO;
 import mx.gob.sedesol.basegestor.service.ParametroSistemaService;
 import mx.gob.sedesol.basegestor.service.admin.AsentamientoService;
@@ -155,6 +156,10 @@ public class PersonaServiceFacade {
 	
 	public List<SelectImportarDTO> consultaFuenteExterna() {
 		return usuariosImportarService.consultaFuenteExterna();
+	}
+
+	public FuenteExternaDTO buscarFuenteExternaPorId(Integer idFuente) {
+		return usuariosImportarService.buscarFuenteExternaPorId(idFuente);
 	}
 
 	public List<SelectImportarDTO> consultaPlanesActivos() {

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
@@ -8,6 +8,7 @@ import javax.annotation.PostConstruct;
 
 import org.apache.log4j.Logger;
 import org.modelmapper.ModelMapper;
+import org.modelmapper.PropertyMap;
 import org.modelmapper.TypeToken;
 import org.modelmapper.TypeMap;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,16 +38,22 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 	private void initMapper() {
 		mapper.getConfiguration().setAmbiguityIgnored(true);
 		TypeMap<PersonaSigeDTO, TblPersonaSige> dtoToEntity = mapper.createTypeMap(PersonaSigeDTO.class, TblPersonaSige.class);
-		dtoToEntity.addMappings(m -> {
-			m.map(PersonaSigeDTO::getIdPersonaSige, TblPersonaSige::setIdPersonaSige);
-			m.map(PersonaSigeDTO::getPersonaIdSige, TblPersonaSige::setPersonaIdSige);
-			m.map(PersonaSigeDTO::getPerfilIdSige, TblPersonaSige::setPerfilIdSige);
+		dtoToEntity.addMappings(new PropertyMap<PersonaSigeDTO, TblPersonaSige>() {
+			@Override
+			protected void configure() {
+				map().setIdPersonaSige(source.getIdPersonaSige());
+				map().setPersonaIdSige(source.getPersonaIdSige());
+				map().setPerfilIdSige(source.getPerfilIdSige());
+			}
 		});
 		TypeMap<TblPersonaSige, PersonaSigeDTO> entityToDto = mapper.createTypeMap(TblPersonaSige.class, PersonaSigeDTO.class);
-		entityToDto.addMappings(m -> {
-			m.map(TblPersonaSige::getIdPersonaSige, PersonaSigeDTO::setIdPersonaSige);
-			m.map(TblPersonaSige::getPersonaIdSige, PersonaSigeDTO::setPersonaIdSige);
-			m.map(TblPersonaSige::getPerfilIdSige, PersonaSigeDTO::setPerfilIdSige);
+		entityToDto.addMappings(new PropertyMap<TblPersonaSige, PersonaSigeDTO>() {
+			@Override
+			protected void configure() {
+				map().setIdPersonaSige(source.getIdPersonaSige());
+				map().setPersonaIdSige(source.getPersonaIdSige());
+				map().setPerfilIdSige(source.getPerfilIdSige());
+			}
 		});
 	}
 	

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
@@ -2,6 +2,7 @@ package mx.gob.sedesol.basegestor.service.impl.admin;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
@@ -224,6 +225,31 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 		}
 		if (actualizarIdsSiempre || dto.getPerfilIdSige() > 0) {
 			entidad.setPerfilIdSige(dto.getPerfilIdSige());
+		}
+		aplicarDefaultsNoNulos(entidad);
+	}
+	
+	private void aplicarDefaultsNoNulos(TblPersonaSige entidad) {
+		if (entidad.getCurp() == null) {
+			entidad.setCurp("");
+		}
+		if (entidad.getProgramaEducativo() == null) {
+			entidad.setProgramaEducativo("");
+		}
+		if (entidad.getDivision() == null) {
+			entidad.setDivision("");
+		}
+		if (entidad.getNivelSige() == null) {
+			entidad.setNivelSige("");
+		}
+		if (entidad.getFechaNacimiento() == null) {
+			entidad.setFechaNacimiento(new Date(0L));
+		}
+		if (entidad.getPersonaIdSige() <= 0) {
+			entidad.setPersonaIdSige(0);
+		}
+		if (entidad.getPerfilIdSige() <= 0) {
+			entidad.setPerfilIdSige(0);
 		}
 	}
 	

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
@@ -90,7 +90,7 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 			if (dto.getPerfilIdSige() <= 0) {
 				dto.setPerfilIdSige(0);
 			}
-			TblPersonaSige entidad = mapper.map(dto, TblPersonaSige.class);
+			TblPersonaSige entidad = new TblPersonaSige();
 			copiarCamposImportacion(dto, entidad, true);
 			boolean passwordPresente = dto.getPassword() != null && !dto.getPassword().isEmpty();
 			logger.info(String.format("Insertando persona SIGE matricula=%s passwordPresent=%s personaIdSige=%d perfilIdSige=%d",

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Service;
 
 import mx.gob.sedesol.basegestor.commons.dto.admin.PersonaSigeDTO;
 import mx.gob.sedesol.basegestor.commons.dto.admin.ResultadoDTO;
+import mx.gob.sedesol.basegestor.commons.utils.MensajesErrorEnum;
+import mx.gob.sedesol.basegestor.commons.utils.ResultadoTransaccionEnum;
 import mx.gob.sedesol.basegestor.model.entities.admin.TblPersonaSige;
 import mx.gob.sedesol.basegestor.model.repositories.admin.PersonaSigeRepo;
 import mx.gob.sedesol.basegestor.service.admin.ComunValidacionService;
@@ -55,23 +57,49 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 	}
 	@Override
 	public PersonaSigeDTO buscarPorId(Long id) {
-		// TODO Auto-generated method stub
-		return null;
+		TblPersonaSige entidad = personaSigeRepo.findOne(id);
+		return entidad != null ? mapper.map(entidad, PersonaSigeDTO.class) : null;
 	}
 	@Override
 	public ResultadoDTO<PersonaSigeDTO> guardar(PersonaSigeDTO dto) {
-		// TODO Auto-generated method stub
-		return null;
+		ResultadoDTO<PersonaSigeDTO> resultado = new ResultadoDTO<>();
+		try {
+			TblPersonaSige entidad = mapper.map(dto, TblPersonaSige.class);
+			TblPersonaSige guardada = personaSigeRepo.save(entidad);
+			resultado.setDto(mapper.map(guardada, PersonaSigeDTO.class));
+		} catch (Exception e) {
+			logger.error("Error al guardar persona sige", e);
+			resultado.setResultado(ResultadoTransaccionEnum.FALLIDO);
+			resultado.setMensajeError(MensajesErrorEnum.ERROR_PERSISTENCIA_DATOS, e.getMessage());
+		}
+		return resultado;
 	}
 	@Override
 	public ResultadoDTO<PersonaSigeDTO> actualizar(PersonaSigeDTO dto) {
-		// TODO Auto-generated method stub
-		return null;
+		ResultadoDTO<PersonaSigeDTO> resultado = new ResultadoDTO<>();
+		try {
+			TblPersonaSige entidad = mapper.map(dto, TblPersonaSige.class);
+			TblPersonaSige actualizada = personaSigeRepo.save(entidad);
+			resultado.setDto(mapper.map(actualizada, PersonaSigeDTO.class));
+		} catch (Exception e) {
+			logger.error("Error al actualizar persona sige", e);
+			resultado.setResultado(ResultadoTransaccionEnum.FALLIDO);
+			resultado.setMensajeError(MensajesErrorEnum.ERROR_PERSISTENCIA_DATOS, e.getMessage());
+		}
+		return resultado;
 	}
 	@Override
 	public ResultadoDTO<PersonaSigeDTO> eliminar(PersonaSigeDTO dto) {
-		// TODO Auto-generated method stub
-		return null;
+		ResultadoDTO<PersonaSigeDTO> resultado = new ResultadoDTO<>();
+		try {
+			TblPersonaSige entidad = mapper.map(dto, TblPersonaSige.class);
+			personaSigeRepo.delete(entidad);
+		} catch (Exception e) {
+			logger.error("Error al eliminar persona sige", e);
+			resultado.setResultado(ResultadoTransaccionEnum.FALLIDO);
+			resultado.setMensajeError(MensajesErrorEnum.ERROR_ELIMINAR_REGISTRO, e.getMessage());
+		}
+		return resultado;
 	}
 	@Override
 	public void validarPersistencia(PersonaSigeDTO dto, ResultadoDTO<PersonaSigeDTO> resultado) {
@@ -121,6 +149,12 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 		}
 		
 		return listaPersonas;
+	}
+
+	@Override
+	public PersonaSigeDTO buscarPorMatricula(String matricula) {
+		TblPersonaSige entidad = personaSigeRepo.findByMatricula(matricula);
+		return entidad != null ? mapper.map(entidad, PersonaSigeDTO.class) : null;
 	}
 	
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
@@ -22,7 +22,7 @@ import mx.gob.sedesol.basegestor.service.admin.PersonaSigeService;
 @Service("personaSigeService")
 public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDTO> implements PersonaSigeService{
 	
-	private static final Logger logger = Logger.getLogger(PersonaServiceImpl.class);
+	private static final Logger logger = Logger.getLogger(PersonaSigeServiceImpl.class);
 	
 	@Autowired
 	private PersonaSigeRepo personaSigeRepo;

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
@@ -2,7 +2,6 @@ package mx.gob.sedesol.basegestor.service.impl.admin;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
@@ -92,11 +91,11 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 	public ResultadoDTO<PersonaSigeDTO> guardar(PersonaSigeDTO dto) {
 		ResultadoDTO<PersonaSigeDTO> resultado = new ResultadoDTO<>();
 		try {
-			if (dto.getPersonaIdSige() <= 0) {
-				dto.setPersonaIdSige(0);
-			}
-			if (dto.getPerfilIdSige() <= 0) {
-				dto.setPerfilIdSige(0);
+			List<String> faltantes = validarCamposObligatorios(dto);
+			if (!faltantes.isEmpty()) {
+				resultado.setResultado(ResultadoTransaccionEnum.FALLIDO);
+				resultado.setMensaje("No se guardó: faltan campos obligatorios: " + String.join(", ", faltantes));
+				return resultado;
 			}
 			TblPersonaSige entidad = new TblPersonaSige();
 			copiarCamposImportacion(dto, entidad, true);
@@ -108,7 +107,12 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 		} catch (Exception e) {
 			logger.error("Error al guardar persona sige", e);
 			resultado.setResultado(ResultadoTransaccionEnum.FALLIDO);
-			resultado.setMensajeError(MensajesErrorEnum.ERROR_PERSISTENCIA_DATOS, e.getMessage());
+			String mensajeAmigable = obtenerMensajeCampoNulo(e);
+			if (mensajeAmigable != null) {
+				resultado.setMensaje(mensajeAmigable);
+			} else {
+				resultado.setMensajeError(MensajesErrorEnum.ERROR_PERSISTENCIA_DATOS, e.getMessage());
+			}
 		}
 		return resultado;
 	}
@@ -119,6 +123,12 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 			if (dto.getIdPersonaSige() == null) {
 				logger.info("DTO sin idPersonaSige, se realizará inserción en lugar de actualización.");
 				return guardar(dto);
+			}
+			List<String> faltantes = validarCamposObligatorios(dto);
+			if (!faltantes.isEmpty()) {
+				resultado.setResultado(ResultadoTransaccionEnum.FALLIDO);
+				resultado.setMensaje("No se actualizó: faltan campos obligatorios: " + String.join(", ", faltantes));
+				return resultado;
 			}
 			TblPersonaSige existente = personaSigeRepo.findOne(dto.getIdPersonaSige());
 			if (existente == null) {
@@ -135,7 +145,12 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 		} catch (Exception e) {
 			logger.error("Error al actualizar persona sige", e);
 			resultado.setResultado(ResultadoTransaccionEnum.FALLIDO);
-			resultado.setMensajeError(MensajesErrorEnum.ERROR_PERSISTENCIA_DATOS, e.getMessage());
+			String mensajeAmigable = obtenerMensajeCampoNulo(e);
+			if (mensajeAmigable != null) {
+				resultado.setMensaje(mensajeAmigable);
+			} else {
+				resultado.setMensajeError(MensajesErrorEnum.ERROR_PERSISTENCIA_DATOS, e.getMessage());
+			}
 		}
 		return resultado;
 	}
@@ -226,31 +241,88 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 		if (actualizarIdsSiempre || dto.getPerfilIdSige() > 0) {
 			entidad.setPerfilIdSige(dto.getPerfilIdSige());
 		}
-		aplicarDefaultsNoNulos(entidad);
 	}
 	
-	private void aplicarDefaultsNoNulos(TblPersonaSige entidad) {
-		if (entidad.getCurp() == null) {
-			entidad.setCurp("");
+	private List<String> validarCamposObligatorios(PersonaSigeDTO dto) {
+		List<String> faltantes = new ArrayList<>();
+		if (dto == null) {
+			faltantes.add("matricula");
+			faltantes.add("password");
+			faltantes.add("nombre");
+			faltantes.add("apellidoPaterno");
+			faltantes.add("apellidoMaterno");
+			faltantes.add("programaEducativo");
+			faltantes.add("division");
+			faltantes.add("correoInstitucional");
+			faltantes.add("fechaNacimiento");
+			faltantes.add("curp");
+			faltantes.add("nivelSige");
+			faltantes.add("personaIdSige");
+			faltantes.add("perfilIdSige");
+			return faltantes;
 		}
-		if (entidad.getProgramaEducativo() == null) {
-			entidad.setProgramaEducativo("");
+		if (esVacio(dto.getMatricula())) {
+			faltantes.add("matricula");
 		}
-		if (entidad.getDivision() == null) {
-			entidad.setDivision("");
+		if (esVacio(dto.getPassword())) {
+			faltantes.add("password");
 		}
-		if (entidad.getNivelSige() == null) {
-			entidad.setNivelSige("");
+		if (esVacio(dto.getNombre())) {
+			faltantes.add("nombre");
 		}
-		if (entidad.getFechaNacimiento() == null) {
-			entidad.setFechaNacimiento(new Date(0L));
+		if (esVacio(dto.getApellidoPaterno())) {
+			faltantes.add("apellidoPaterno");
 		}
-		if (entidad.getPersonaIdSige() <= 0) {
-			entidad.setPersonaIdSige(0);
+		if (esVacio(dto.getApellidoMaterno())) {
+			faltantes.add("apellidoMaterno");
 		}
-		if (entidad.getPerfilIdSige() <= 0) {
-			entidad.setPerfilIdSige(0);
+		if (esVacio(dto.getProgramaEducativo())) {
+			faltantes.add("programaEducativo");
 		}
+		if (esVacio(dto.getDivision())) {
+			faltantes.add("division");
+		}
+		if (esVacio(dto.getCorreoInstitucional())) {
+			faltantes.add("correoInstitucional");
+		}
+		if (dto.getFechaNacimiento() == null) {
+			faltantes.add("fechaNacimiento");
+		}
+		if (esVacio(dto.getCurp())) {
+			faltantes.add("curp");
+		}
+		if (esVacio(dto.getNivelSige())) {
+			faltantes.add("nivelSige");
+		}
+		if (dto.getPersonaIdSige() == null || dto.getPersonaIdSige() <= 0) {
+			faltantes.add("personaIdSige");
+		}
+		if (dto.getPerfilIdSige() == null || dto.getPerfilIdSige() <= 0) {
+			faltantes.add("perfilIdSige");
+		}
+		return faltantes;
+	}
+
+	private boolean esVacio(String valor) {
+		return valor == null || valor.trim().isEmpty();
+	}
+
+	private String obtenerMensajeCampoNulo(Exception e) {
+		Throwable causa = e;
+		while (causa != null) {
+			String mensaje = causa.getMessage();
+			if (mensaje != null && mensaje.contains("Column '") && mensaje.contains("cannot be null")) {
+				int inicio = mensaje.indexOf("Column '") + "Column '".length();
+				int fin = mensaje.indexOf("'", inicio);
+				if (fin > inicio) {
+					String campo = mensaje.substring(inicio, fin);
+					return "No se guardó: el campo requerido '" + campo
+							+ "' viene vacío. Revise la consulta de la fuente externa.";
+				}
+			}
+			causa = causa.getCause();
+		}
+		return null;
 	}
 	
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
@@ -25,15 +25,15 @@ import mx.gob.sedesol.basegestor.service.admin.PersonaSigeService;
 
 @Service("personaSigeService")
 public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDTO> implements PersonaSigeService{
-	
+
 	private static final Logger logger = Logger.getLogger(PersonaSigeServiceImpl.class);
-	
+
 	@Autowired
 	private PersonaSigeRepo personaSigeRepo;
 	private ModelMapper mapper = new ModelMapper();
 	Type personaSigeDTO = new TypeToken<List<PersonaSigeDTO>>() {
 	}.getType();
-	
+
 	@PostConstruct
 	private void initMapper() {
 		mapper.getConfiguration().setAmbiguityIgnored(true);
@@ -56,7 +56,7 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 			}
 		});
 	}
-	
+
 	@Override
 	public List<PersonaSigeDTO> findAll() {
 		List<PersonaSigeDTO> listaPersonas = new ArrayList<PersonaSigeDTO>();
@@ -79,7 +79,7 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 			personaObj.setPassword(persona.getPassword());
 			listaPersonas.add(personaObj);
 		}
-		
+
 		return listaPersonas;
 	}
 	@Override
@@ -170,17 +170,17 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 	@Override
 	public void validarPersistencia(PersonaSigeDTO dto, ResultadoDTO<PersonaSigeDTO> resultado) {
 		// TODO Auto-generated method stub
-		
+
 	}
 	@Override
 	public void validarActualizacion(PersonaSigeDTO dto, ResultadoDTO<PersonaSigeDTO> resultado) {
 		// TODO Auto-generated method stub
-		
+
 	}
 	@Override
 	public void validarEliminacion(PersonaSigeDTO dto, ResultadoDTO<PersonaSigeDTO> resultado) {
 		// TODO Auto-generated method stub
-		
+
 	}
 	public PersonaSigeRepo getPersonaSigeRepo() {
 		return personaSigeRepo;
@@ -210,10 +210,10 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 				personaObj.setPersonaIdSige(persona.getPersonaIdSige());
 				personaObj.setPerfilIdSige(persona.getPerfilIdSige());
 				personaObj.setPassword(persona.getPassword());
-				listaPersonas.add(personaObj);				
+				listaPersonas.add(personaObj);
 			}
 		}
-		
+
 		return listaPersonas;
 	}
 
@@ -222,7 +222,7 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 		TblPersonaSige entidad = personaSigeRepo.findByMatricula(matricula);
 		return entidad != null ? mapper.map(entidad, PersonaSigeDTO.class) : null;
 	}
-	
+
 	private void copiarCamposImportacion(PersonaSigeDTO dto, TblPersonaSige entidad, boolean actualizarIdsSiempre) {
 		entidad.setMatricula(dto.getMatricula());
 		entidad.setNombre(dto.getNombre());
@@ -242,7 +242,7 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 			entidad.setPerfilIdSige(dto.getPerfilIdSige());
 		}
 	}
-	
+
 	private List<String> validarCamposObligatorios(PersonaSigeDTO dto) {
 		List<String> faltantes = new ArrayList<>();
 		if (dto == null) {
@@ -257,8 +257,8 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 			faltantes.add("fechaNacimiento");
 			faltantes.add("curp");
 			faltantes.add("nivelSige");
-			faltantes.add("personaIdSige");
-			faltantes.add("perfilIdSige");
+			faltantes.add("persona_id_sige");
+			faltantes.add("perfil_id_sige");
 			return faltantes;
 		}
 		if (esVacio(dto.getMatricula())) {
@@ -294,11 +294,11 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 		if (esVacio(dto.getNivelSige())) {
 			faltantes.add("nivelSige");
 		}
-		if (dto.getPersonaIdSige() == null || dto.getPersonaIdSige() <= 0) {
-			faltantes.add("personaIdSige");
+		if (dto.getPersonaIdSige() <= 0) {
+			faltantes.add("persona_id_sige");
 		}
-		if (dto.getPerfilIdSige() == null || dto.getPerfilIdSige() <= 0) {
-			faltantes.add("perfilIdSige");
+		if (dto.getPerfilIdSige() <= 0) {
+			faltantes.add("perfil_id_sige");
 		}
 		return faltantes;
 	}
@@ -324,5 +324,5 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 		}
 		return null;
 	}
-	
+
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
@@ -148,7 +148,7 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 		} catch (Exception e) {
 			logger.error("Error al eliminar persona sige", e);
 			resultado.setResultado(ResultadoTransaccionEnum.FALLIDO);
-			resultado.setMensajeError(MensajesErrorEnum.ERROR_ELIMINAR_REGISTRO, e.getMessage());
+			resultado.setMensajeError(MensajesErrorEnum.ERROR_ELIMINAR_DATOS, e.getMessage());
 		}
 		return resultado;
 	}

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
@@ -4,9 +4,12 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.PostConstruct;
+
 import org.apache.log4j.Logger;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
+import org.modelmapper.TypeMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -29,6 +32,23 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 	private ModelMapper mapper = new ModelMapper();
 	Type personaSigeDTO = new TypeToken<List<PersonaSigeDTO>>() {
 	}.getType();
+	
+	@PostConstruct
+	private void initMapper() {
+		mapper.getConfiguration().setAmbiguityIgnored(true);
+		TypeMap<PersonaSigeDTO, TblPersonaSige> dtoToEntity = mapper.createTypeMap(PersonaSigeDTO.class, TblPersonaSige.class);
+		dtoToEntity.addMappings(m -> {
+			m.map(PersonaSigeDTO::getIdPersonaSige, TblPersonaSige::setIdPersonaSige);
+			m.map(PersonaSigeDTO::getPersonaIdSige, TblPersonaSige::setPersonaIdSige);
+			m.map(PersonaSigeDTO::getPerfilIdSige, TblPersonaSige::setPerfilIdSige);
+		});
+		TypeMap<TblPersonaSige, PersonaSigeDTO> entityToDto = mapper.createTypeMap(TblPersonaSige.class, PersonaSigeDTO.class);
+		entityToDto.addMappings(m -> {
+			m.map(TblPersonaSige::getIdPersonaSige, PersonaSigeDTO::setIdPersonaSige);
+			m.map(TblPersonaSige::getPersonaIdSige, PersonaSigeDTO::setPersonaIdSige);
+			m.map(TblPersonaSige::getPerfilIdSige, PersonaSigeDTO::setPerfilIdSige);
+		});
+	}
 	
 	@Override
 	public List<PersonaSigeDTO> findAll() {
@@ -64,7 +84,17 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 	public ResultadoDTO<PersonaSigeDTO> guardar(PersonaSigeDTO dto) {
 		ResultadoDTO<PersonaSigeDTO> resultado = new ResultadoDTO<>();
 		try {
+			if (dto.getPersonaIdSige() <= 0) {
+				dto.setPersonaIdSige(0);
+			}
+			if (dto.getPerfilIdSige() <= 0) {
+				dto.setPerfilIdSige(0);
+			}
 			TblPersonaSige entidad = mapper.map(dto, TblPersonaSige.class);
+			copiarCamposImportacion(dto, entidad, true);
+			boolean passwordPresente = dto.getPassword() != null && !dto.getPassword().isEmpty();
+			logger.info(String.format("Insertando persona SIGE matricula=%s passwordPresent=%s personaIdSige=%d perfilIdSige=%d",
+					entidad.getMatricula(), passwordPresente, entidad.getPersonaIdSige(), entidad.getPerfilIdSige()));
 			TblPersonaSige guardada = personaSigeRepo.save(entidad);
 			resultado.setDto(mapper.map(guardada, PersonaSigeDTO.class));
 		} catch (Exception e) {
@@ -78,8 +108,21 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 	public ResultadoDTO<PersonaSigeDTO> actualizar(PersonaSigeDTO dto) {
 		ResultadoDTO<PersonaSigeDTO> resultado = new ResultadoDTO<>();
 		try {
-			TblPersonaSige entidad = mapper.map(dto, TblPersonaSige.class);
-			TblPersonaSige actualizada = personaSigeRepo.save(entidad);
+			if (dto.getIdPersonaSige() == null) {
+				logger.info("DTO sin idPersonaSige, se realizará inserción en lugar de actualización.");
+				return guardar(dto);
+			}
+			TblPersonaSige existente = personaSigeRepo.findOne(dto.getIdPersonaSige());
+			if (existente == null) {
+				logger.info(String.format("No se encontró persona SIGE id=%s, se realizará inserción.", dto.getIdPersonaSige()));
+				return guardar(dto);
+			}
+			copiarCamposImportacion(dto, existente, false);
+			boolean passwordPresente = dto.getPassword() != null && !dto.getPassword().isEmpty();
+			logger.info(String.format("Actualizando persona SIGE id=%s matricula=%s passwordPresent=%s personaIdSige=%d perfilIdSige=%d",
+					existente.getIdPersonaSige(), existente.getMatricula(), passwordPresente, existente.getPersonaIdSige(),
+					existente.getPerfilIdSige()));
+			TblPersonaSige actualizada = personaSigeRepo.save(existente);
 			resultado.setDto(mapper.map(actualizada, PersonaSigeDTO.class));
 		} catch (Exception e) {
 			logger.error("Error al actualizar persona sige", e);
@@ -155,6 +198,26 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 	public PersonaSigeDTO buscarPorMatricula(String matricula) {
 		TblPersonaSige entidad = personaSigeRepo.findByMatricula(matricula);
 		return entidad != null ? mapper.map(entidad, PersonaSigeDTO.class) : null;
+	}
+	
+	private void copiarCamposImportacion(PersonaSigeDTO dto, TblPersonaSige entidad, boolean actualizarIdsSiempre) {
+		entidad.setMatricula(dto.getMatricula());
+		entidad.setNombre(dto.getNombre());
+		entidad.setApellidoPaterno(dto.getApellidoPaterno());
+		entidad.setApellidoMaterno(dto.getApellidoMaterno());
+		entidad.setProgramaEducativo(dto.getProgramaEducativo());
+		entidad.setDivision(dto.getDivision());
+		entidad.setCorreoInstitucional(dto.getCorreoInstitucional());
+		entidad.setFechaNacimiento(dto.getFechaNacimiento());
+		entidad.setCurp(dto.getCurp());
+		entidad.setNivelSige(dto.getNivelSige());
+		entidad.setPassword(dto.getPassword());
+		if (actualizarIdsSiempre || dto.getPersonaIdSige() > 0) {
+			entidad.setPersonaIdSige(dto.getPersonaIdSige());
+		}
+		if (actualizarIdsSiempre || dto.getPerfilIdSige() > 0) {
+			entidad.setPerfilIdSige(dto.getPerfilIdSige());
+		}
 	}
 	
 }

--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/UsuariosImportarServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/UsuariosImportarServiceImpl.java
@@ -1,26 +1,14 @@
 package mx.gob.sedesol.basegestor.service.impl.admin;
 
-import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.List;
 
-import org.modelmapper.ModelMapper;
-import org.modelmapper.TypeToken;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import mx.gob.sedesol.basegestor.commons.dto.admin.DiscapacidadDTO;
-import mx.gob.sedesol.basegestor.commons.dto.admin.MunicipioDTO;
+import mx.gob.sedesol.basegestor.commons.dto.admin.FuenteExternaDTO;
 import mx.gob.sedesol.basegestor.commons.dto.admin.PersonaSigeDTO;
-import mx.gob.sedesol.basegestor.commons.dto.admin.TipoDiscapacidadDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.SelectImportarDTO;
-import mx.gob.sedesol.basegestor.commons.utils.ObjectUtils;
-import mx.gob.sedesol.basegestor.model.entities.admin.CatDiscapacidad;
-import mx.gob.sedesol.basegestor.model.entities.admin.CatTipoDiscapacidad;
-import mx.gob.sedesol.basegestor.model.repositories.admin.DiscapacidadRepo;
 import mx.gob.sedesol.basegestor.model.repositories.admin.IUsuariosImportarRepo;
-import mx.gob.sedesol.basegestor.model.repositories.admin.TipoDiscapacidadRepo;
-import mx.gob.sedesol.basegestor.service.admin.DiscapacidadService;
 import mx.gob.sedesol.basegestor.service.gestionescolar.UsuariosImportarService;
 
 
@@ -42,6 +30,11 @@ public class UsuariosImportarServiceImpl implements UsuariosImportarService{
 	@Override
 	public List<SelectImportarDTO> consultaFuenteExterna() {
 		return usuariosImportarRepo.consultaFuenteExterna();
+	}
+
+	@Override
+	public FuenteExternaDTO buscarFuenteExternaPorId(Integer idFuente) {
+		return usuariosImportarRepo.buscarFuenteExternaPorId(idFuente);
 	}
 
 	@Override

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml
@@ -236,8 +236,9 @@
             </h:form>
 
             <p:dialog appendTo="@(body)" draggable="false" position="center"
-                      resizable="false" closable="false" modal="true" width="600px"
-                      widgetVar="dlgNuevaAltaValidacion" header="Informativo" dynamic="true">
+                      resizable="false" closable="false" modal="true"
+                      widgetVar="dlgNuevaAltaValidacion" header="Informativo" dynamic="true"
+                      styleClass="medidaModal">
                 <div class="form-group">
                     <div class="row">
                         <div class="col-md-12">
@@ -257,8 +258,9 @@
             </p:dialog>
 
             <p:dialog appendTo="@(body)" draggable="false" position="center"
-                      resizable="false" closable="false" modal="true" width="600px"
-                      widgetVar="dlgNuevaAltaExito" header="Informativo" dynamic="true">
+                      resizable="false" closable="false" modal="true"
+                      widgetVar="dlgNuevaAltaExito" header="Informativo" dynamic="true"
+                      styleClass="medidaModal">
                 <div class="form-group">
                     <div class="row">
                         <div class="col-md-12">
@@ -278,8 +280,9 @@
             </p:dialog>
 
             <p:dialog appendTo="@(body)" draggable="false" position="center"
-                      resizable="false" closable="false" modal="true" width="600px"
-                      widgetVar="dlgNuevaAltaError" header="Informativo" dynamic="true">
+                      resizable="false" closable="false" modal="true"
+                      widgetVar="dlgNuevaAltaError" header="Informativo" dynamic="true"
+                      styleClass="medidaModal">
                 <div class="form-group">
                     <div class="row">
                         <div class="col-md-12">

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml
@@ -50,7 +50,7 @@
                             <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.btn.importar')}"
                                              action="#{nuevaAltaUsuariosBean.importarDesdeFuenteExterna}"
                                              process="@form"
-                                             update="@form :frmNuevaAlta"
+                                             update="@form :frmAltasBajas:panelContenido :frmAltasBajas:msgsAltasBajas"
                                              onstart="PF('dialogLayout').show();"
                                              oncomplete="PF('dialogLayout').hide();"
                                              onerror="PF('dialogLayout').hide();"

--- a/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml
+++ b/codigoFuente/gestorWeb/WebContent/views/private/gestionEscolar/altasBajasUsuarios/nuevaAlta.xhtml
@@ -25,7 +25,8 @@
                                                styleClass="requerido bloque" />
                                 <p:inputText id="txtMatriculaImportar"
                                              styleClass="form-control"
-                                             style="width: 100%;" />
+                                             style="width: 100%;"
+                                             value="#{nuevaAltaUsuariosBean.matriculaImportar}" />
                             </div>
                             <div class="col-md-6 col-sm-6 col-xs-12">
                                 <p:outputLabel for="somFuenteExterna"
@@ -47,7 +48,12 @@
                     <div class="row" style="margin-top: 20px;">
                         <div class="col-md-12 text-right">
                             <p:commandButton value="#{sistema.obtenerTexto('gw.gestionescolar.altasbajas.btn.importar')}"
-                                             type="button"
+                                             action="#{nuevaAltaUsuariosBean.importarDesdeFuenteExterna}"
+                                             process="@form"
+                                             update="@form :frmNuevaAlta"
+                                             onstart="PF('dialogLayout').show();"
+                                             oncomplete="PF('dialogLayout').hide();"
+                                             onerror="PF('dialogLayout').hide();"
                                              styleClass="btn btn-primary" />
                         </div>
                     </div>

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
@@ -95,7 +95,7 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
     public void importarDesdeFuenteExterna() {
         try {
             if (esVacio(matriculaImportar) || esVacio(fuenteExternaSeleccionada)) {
-                agregarMsgWarn("Configurar correctamente los datos de la fuente externa", null);
+                agregarMsgWarn("Capture matrícula y seleccione fuente externa.", null);
                 return;
             }
 
@@ -527,9 +527,14 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
     private void manejarResultadoPersistencia(ResultadoDTO<PersonaSigeDTO> resultado) {
         if (ObjectUtils.isNull(resultado) || !resultado.esCorrecto() || ObjectUtils.isNull(resultado.getDto())) {
-            String mensaje = resultado != null && !ObjectUtils.isNullOrEmpty(resultado.getMensajes())
-                    ? resultado.getMensajes().get(0)
-                    : "No se pudo guardar la información de la persona SIGE";
+            String mensaje = "No se pudo guardar la información de la persona SIGE";
+            if (resultado != null) {
+                if (!ObjectUtils.isNullOrEmpty(resultado.getMensajes())) {
+                    mensaje = resultado.getMensajes().get(0);
+                } else if (!esVacio(resultado.getMensaje())) {
+                    mensaje = resultado.getMensaje();
+                }
+            }
             throw new RuntimeException(mensaje);
         }
     }

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
@@ -26,6 +26,7 @@ import mx.gob.sedesol.basegestor.commons.dto.admin.ParametroWSMoodleDTO;
 import mx.gob.sedesol.basegestor.commons.dto.admin.PersonaDTO;
 import mx.gob.sedesol.basegestor.commons.dto.admin.PersonaSigeDTO;
 import mx.gob.sedesol.basegestor.commons.dto.admin.FuenteExternaDTO;
+import mx.gob.sedesol.basegestor.commons.dto.admin.ResultadoDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.EventoCapacitacionDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.GrupoDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.RelGrupoParticipanteDTO;
@@ -141,7 +142,9 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
             }
         } catch (Exception e) {
             LOGGER.error("Error al importar datos desde fuente externa", e);
-            agregarMsgError(e.getMessage(), null);
+            String mensaje = ObjectUtils.isNullOrEmpty(e.getMessage()) ? "Error al importar datos desde fuente externa"
+                    : e.getMessage();
+            agregarMsgError(mensaje, null);
         }
     }
 
@@ -387,14 +390,39 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
         }
     }
 
+    private int contarOcurrencias(String cadena, String subcadena) {
+        if (esVacio(cadena) || esVacio(subcadena)) {
+            return 0;
+        }
+        int contador = 0;
+        int indice = cadena.indexOf(subcadena);
+        while (indice != -1) {
+            contador++;
+            indice = cadena.indexOf(subcadena, indice + subcadena.length());
+        }
+        return contador;
+    }
+
+    private int contarOcurrenciasIgnoreCase(String cadena, String subcadena) {
+        if (cadena == null || subcadena == null) {
+            return 0;
+        }
+        return contarOcurrencias(cadena.toLowerCase(), subcadena.toLowerCase());
+    }
+
     private String normalizarConsulta(String consulta) {
-        if (consulta.contains("?")) {
-            return consulta;
+        if (esVacio(consulta)) {
+            return null;
         }
-        if (consulta.toLowerCase().contains(":matricula")) {
-            return consulta.replaceAll("(?i):matricula", "?");
+        int numInterrogaciones = contarOcurrencias(consulta, "?");
+        int numMatricula = contarOcurrenciasIgnoreCase(consulta, ":matricula");
+        int numUsuario = contarOcurrenciasIgnoreCase(consulta, ":usuario");
+        int totalParametros = numInterrogaciones + numMatricula + numUsuario;
+        if (totalParametros != 1) {
+            return null;
         }
-        return null;
+        String consultaNormalizada = consulta.replaceAll("(?i):matricula", "?").replaceAll("(?i):usuario", "?");
+        return consultaNormalizada;
     }
 
     private Connection crearConexion(FuenteExternaDTO fuente) throws SQLException {
@@ -414,23 +442,11 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
         if (!esVacio(fuente.getUsuario())) {
             propiedades.put("user", fuente.getUsuario());
         }
-        String password = obtenerPassword(fuente.getAlias());
+        String password = fuente.getContrasena();
         if (!esVacio(password)) {
             propiedades.put("password", password);
         }
         return DriverManager.getConnection(url, propiedades);
-    }
-
-    private String obtenerPassword(String alias) {
-        if (esVacio(alias)) {
-            return null;
-        }
-        String porPropiedad = System.getProperty("fuente.externa." + alias + ".password");
-        if (!esVacio(porPropiedad)) {
-            return porPropiedad;
-        }
-        String porAmbiente = System.getenv("FUENTE_EXTERNA_" + alias.toUpperCase() + "_PASSWORD");
-        return porAmbiente;
     }
 
     private PersonaSigeDTO mapearPersonaSige(ResultSet rs) throws SQLException {
@@ -446,8 +462,14 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
         persona.setFechaNacimiento(obtenerFecha(rs, "fecha_nacimiento", "fecha_nacimiento_sige"));
         persona.setCurp(obtenerString(rs, "curp", "curp_sige"));
         persona.setNivelSige(obtenerString(rs, "nivel", "nivel_sige"));
-        persona.setPersonaIdSige(obtenerEntero(rs, "persona_id", "persona_id_sige"));
-        persona.setPerfilIdSige(obtenerEntero(rs, "perfil_id", "perfil_id_sige"));
+        Integer personaId = obtenerEntero(rs, "persona_id", "persona_id_sige");
+        Integer perfilId = obtenerEntero(rs, "perfil_id", "perfil_id_sige");
+        if (personaId != null) {
+            persona.setPersonaIdSige(personaId);
+        }
+        if (perfilId != null) {
+            persona.setPerfilIdSige(perfilId);
+        }
         return persona;
     }
 
@@ -470,13 +492,16 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
         return null;
     }
 
-    private int obtenerEntero(ResultSet rs, String... columnas) throws SQLException {
+    private Integer obtenerEntero(ResultSet rs, String... columnas) throws SQLException {
         for (String columna : columnas) {
             if (tieneColumna(rs, columna)) {
-                return rs.getInt(columna);
+                Object valor = rs.getObject(columna);
+                if (valor instanceof Number) {
+                    return ((Number) valor).intValue();
+                }
             }
         }
-        return 0;
+        return null;
     }
 
     private boolean tieneColumna(ResultSet rs, String columna) throws SQLException {
@@ -494,13 +519,18 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
         PersonaSigeDTO existente = personaSigeService.buscarPorMatricula(personaSige.getMatricula());
         if (ObjectUtils.isNotNull(existente)) {
             personaSige.setIdPersonaSige(existente.getIdPersonaSige());
-            if (ObjectUtils.isNull(personaSigeService.actualizar(personaSige).getDto())) {
-                LOGGER.warn("No se pudo actualizar la información de la persona SIGE");
-            }
+            manejarResultadoPersistencia(personaSigeService.actualizar(personaSige));
         } else {
-            if (ObjectUtils.isNull(personaSigeService.guardar(personaSige).getDto())) {
-                LOGGER.warn("No se pudo guardar la información de la persona SIGE");
-            }
+            manejarResultadoPersistencia(personaSigeService.guardar(personaSige));
+        }
+    }
+
+    private void manejarResultadoPersistencia(ResultadoDTO<PersonaSigeDTO> resultado) {
+        if (ObjectUtils.isNull(resultado) || !resultado.esCorrecto() || ObjectUtils.isNull(resultado.getDto())) {
+            String mensaje = resultado != null && !ObjectUtils.isNullOrEmpty(resultado.getMensajes())
+                    ? resultado.getMensajes().get(0)
+                    : "No se pudo guardar la información de la persona SIGE";
+            throw new RuntimeException(mensaje);
         }
     }
 

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
@@ -43,6 +43,10 @@ import mx.gob.sedesol.gestorweb.beans.acceso.BaseBean;
 public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
     private static final long serialVersionUID = 1L;
+    private static final List<String> COLUMNAS_REQUERIDAS = Arrays.asList("matricula_sige", "password_sige",
+            "nombre_sige", "apellidop_sige", "apellidom_sige", "programa_sige", "division_sige",
+            "correo_institucional_sige", "fecha_nacimiento_sige", "curp_sige", "nivel_sige", "persona_id_sige",
+            "perfil_id_sige");
 
     @ManagedProperty("#{personaServiceFacade}")
     private transient PersonaServiceFacade personaServiceFacade;
@@ -167,20 +171,38 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                                     matriculaImportar.trim()));
                             return;
                         }
+                        List<String> columnasFaltantes = validarColumnasRequeridas(rs);
+                        if (!columnasFaltantes.isEmpty()) {
+                            String columnasActuales = obtenerColumnas(rs);
+                            LOGGER.warn(String.format(
+                                    "[%s] ResultSet sin columnas requeridas. Faltantes=%s, Columnas=%s", traceId,
+                                    columnasFaltantes, columnasActuales));
+                            agregarMsgWarn("La consulta de la fuente externa no incluye las columnas requeridas: "
+                                    + String.join(", ", columnasFaltantes), null);
+                            return;
+                        }
                         LOGGER.info(String.format("[%s] ResultSet con datos. Columnas=%s", traceId,
                                 obtenerColumnas(rs)));
                         PersonaSigeDTO personaSige = mapearPersonaSige(rs);
                         LOGGER.info(String.format(
-                                "[%s] Datos mapeo previo a validación de matrícula. Columnas=%s, username=%s, firstname=%s, lastname=%s, email=%s, passwordPresent=%s, matriculaFinal=%s",
-                                traceId, obtenerColumnas(rs), obtenerString(rs, "username"), obtenerString(rs, "firstname"),
-                                obtenerString(rs, "lastname"), obtenerString(rs, "email"),
-                                !esVacio(obtenerString(rs, "password")),
+                                "[%s] Datos mapeo previo a validación de matrícula. Columnas=%s, passwordPresent=%s, matriculaFinal=%s",
+                                traceId, obtenerColumnas(rs), !esVacio(personaSige.getPassword()),
                                 ObjectUtils.isNull(personaSige) ? null : personaSige.getMatricula()));
                         if (ObjectUtils.isNull(personaSige) || esVacio(personaSige.getMatricula())) {
                             agregarMsgWarn(
-                                    "La fuente externa no devolvió matrícula (se esperaba username). Revise la consulta/mapeo.",
+                                    "La fuente externa no devolvió matrícula (se esperaba matricula_sige). Revise la consulta/mapeo.",
                                     null);
                             LOGGER.warn(String.format("[%s] PersonaSige mapeada sin matrícula.", traceId));
+                            return;
+                        }
+                        List<String> camposFaltantes = validarCamposObligatorios(personaSige);
+                        if (!camposFaltantes.isEmpty()) {
+                            LOGGER.warn(String.format("[%s] PersonaSige con campos obligatorios vacíos. Faltantes=%s",
+                                    traceId, camposFaltantes));
+                            agregarMsgWarn(
+                                    "La fuente externa devolvió campos obligatorios vacíos: "
+                                            + String.join(", ", camposFaltantes),
+                                    null);
                             return;
                         }
                         LOGGER.info(String.format(
@@ -498,48 +520,19 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
     private PersonaSigeDTO mapearPersonaSige(ResultSet rs) throws SQLException {
         PersonaSigeDTO persona = new PersonaSigeDTO();
-        String matricula = obtenerString(rs, "matricula", "matricula_sige");
-        if (esVacio(matricula) && tieneColumna(rs, "username")) {
-            matricula = rs.getString("username");
-        }
-        persona.setMatricula(matricula);
-
-        persona.setPassword(obtenerString(rs, "password", "password_sige"));
-
-        String nombre = obtenerString(rs, "nombre", "nombre_sige");
-        if (esVacio(nombre) && tieneColumna(rs, "firstname")) {
-            nombre = rs.getString("firstname");
-        }
-        persona.setNombre(nombre);
-
-        String apellidoPaterno = obtenerString(rs, "apellido_paterno", "apellidop_sige");
-        String apellidoMaterno = obtenerString(rs, "apellido_materno", "apellidom_sige");
-        if (esVacio(apellidoPaterno) && esVacio(apellidoMaterno) && tieneColumna(rs, "lastname")) {
-            String lastname = rs.getString("lastname");
-            if (!esVacio(lastname)) {
-                String[] partes = lastname.trim().split("\\s+");
-                if (partes.length > 0) {
-                    apellidoPaterno = partes[0];
-                    if (partes.length > 1) {
-                        apellidoMaterno = String.join(" ", Arrays.copyOfRange(partes, 1, partes.length));
-                    }
-                }
-            }
-        }
-        persona.setApellidoPaterno(apellidoPaterno);
-        persona.setApellidoMaterno(apellidoMaterno);
-        persona.setProgramaEducativo(obtenerString(rs, "programa_educativo", "programa_educativo_sige"));
-        persona.setDivision(obtenerString(rs, "division", "division_sige"));
-        String correo = obtenerString(rs, "correo_institucional", "correo_institucional_sige");
-        if (esVacio(correo) && tieneColumna(rs, "email")) {
-            correo = rs.getString("email");
-        }
-        persona.setCorreoInstitucional(correo);
-        persona.setFechaNacimiento(obtenerFecha(rs, "fecha_nacimiento", "fecha_nacimiento_sige"));
-        persona.setCurp(obtenerString(rs, "curp", "curp_sige"));
-        persona.setNivelSige(obtenerString(rs, "nivel", "nivel_sige"));
-        Integer personaId = obtenerEntero(rs, "persona_id", "persona_id_sige");
-        Integer perfilId = obtenerEntero(rs, "perfil_id", "perfil_id_sige");
+        persona.setMatricula(obtenerString(rs, "matricula_sige"));
+        persona.setPassword(obtenerString(rs, "password_sige"));
+        persona.setNombre(obtenerString(rs, "nombre_sige"));
+        persona.setApellidoPaterno(obtenerString(rs, "apellidop_sige"));
+        persona.setApellidoMaterno(obtenerString(rs, "apellidom_sige"));
+        persona.setProgramaEducativo(obtenerString(rs, "programa_sige"));
+        persona.setDivision(obtenerString(rs, "division_sige"));
+        persona.setCorreoInstitucional(obtenerString(rs, "correo_institucional_sige"));
+        persona.setFechaNacimiento(obtenerFecha(rs, "fecha_nacimiento_sige"));
+        persona.setCurp(obtenerString(rs, "curp_sige"));
+        persona.setNivelSige(obtenerString(rs, "nivel_sige"));
+        Integer personaId = obtenerEntero(rs, "persona_id_sige");
+        Integer perfilId = obtenerEntero(rs, "perfil_id_sige");
         if (personaId != null) {
             persona.setPersonaIdSige(personaId);
         }
@@ -599,6 +592,64 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
             nombres.add(metaData.getColumnLabel(i));
         }
         return nombres.toString();
+    }
+
+    private List<String> validarColumnasRequeridas(ResultSet rs) throws SQLException {
+        List<String> faltantes = new ArrayList<>();
+        for (String columna : COLUMNAS_REQUERIDAS) {
+            if (!tieneColumna(rs, columna)) {
+                faltantes.add(columna);
+            }
+        }
+        return faltantes;
+    }
+
+    private List<String> validarCamposObligatorios(PersonaSigeDTO personaSige) {
+        List<String> faltantes = new ArrayList<>();
+        if (ObjectUtils.isNull(personaSige)) {
+            faltantes.addAll(COLUMNAS_REQUERIDAS);
+            return faltantes;
+        }
+        if (esVacio(personaSige.getMatricula())) {
+            faltantes.add("matricula_sige");
+        }
+        if (esVacio(personaSige.getPassword())) {
+            faltantes.add("password_sige");
+        }
+        if (esVacio(personaSige.getNombre())) {
+            faltantes.add("nombre_sige");
+        }
+        if (esVacio(personaSige.getApellidoPaterno())) {
+            faltantes.add("apellidop_sige");
+        }
+        if (esVacio(personaSige.getApellidoMaterno())) {
+            faltantes.add("apellidom_sige");
+        }
+        if (esVacio(personaSige.getProgramaEducativo())) {
+            faltantes.add("programa_sige");
+        }
+        if (esVacio(personaSige.getDivision())) {
+            faltantes.add("division_sige");
+        }
+        if (esVacio(personaSige.getCorreoInstitucional())) {
+            faltantes.add("correo_institucional_sige");
+        }
+        if (ObjectUtils.isNull(personaSige.getFechaNacimiento())) {
+            faltantes.add("fecha_nacimiento_sige");
+        }
+        if (esVacio(personaSige.getCurp())) {
+            faltantes.add("curp_sige");
+        }
+        if (esVacio(personaSige.getNivelSige())) {
+            faltantes.add("nivel_sige");
+        }
+        if (ObjectUtils.isNull(personaSige.getPersonaIdSige())) {
+            faltantes.add("persona_id_sige");
+        }
+        if (ObjectUtils.isNull(personaSige.getPerfilIdSige())) {
+            faltantes.add("perfil_id_sige");
+        }
+        return faltantes;
     }
 
     private String construirUrlConexion(FuenteExternaDTO fuente) {

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
@@ -221,7 +221,7 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                                 personaSige.getApellidoPaterno(), personaSige.getApellidoMaterno(),
                                 personaSige.getCorreoInstitucional()));
                         guardarPersonaSige(personaSige, traceId);
-                        matriculaNuevaAlta = personaSige.getMatricula();
+                        matriculaNuevaAlta = null;
                         matriculaImportar = null;
                         fuenteExternaSeleccionada = null;
                         mostrarDialogoExito(obtenerTextoSistema(

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
@@ -93,50 +93,97 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
     }
 
     public void importarDesdeFuenteExterna() {
+        String traceId = "IMP-" + System.currentTimeMillis();
         try {
+            LOGGER.info(String.format("[%s] Iniciando importación. Matricula: %s, Fuente seleccionada: %s", traceId,
+                    matriculaImportar != null ? matriculaImportar.trim() : null, fuenteExternaSeleccionada));
             if (esVacio(matriculaImportar) || esVacio(fuenteExternaSeleccionada)) {
                 agregarMsgWarn("Capture matrícula y seleccione fuente externa.", null);
+                LOGGER.warn(String.format("[%s] Faltan datos de entrada para importar.", traceId));
                 return;
             }
 
             Integer idFuente = parseEntero(fuenteExternaSeleccionada);
             if (ObjectUtils.isNull(idFuente)) {
-                agregarMsgWarn("Configurar correctamente los datos de la fuente externa", null);
+                agregarMsgWarn("Fuente externa inválida.", null);
+                LOGGER.warn(String.format("[%s] No se pudo parsear la fuente externa seleccionada: %s", traceId,
+                        fuenteExternaSeleccionada));
                 return;
             }
+            LOGGER.info(String.format("[%s] Fuente externa parseada. idFuente=%s", traceId, idFuente));
 
             FuenteExternaDTO fuente = personaServiceFacade.buscarFuenteExternaPorId(idFuente);
-            if (ObjectUtils.isNull(fuente) || esVacio(fuente.getConsulta())) {
-                agregarMsgWarn("Configurar correctamente los datos de la fuente externa", null);
+            if (ObjectUtils.isNull(fuente)) {
+                agregarMsgWarn("No se encontró la configuración de la fuente externa.", null);
+                LOGGER.warn(String.format("[%s] Fuente externa no encontrada. idFuente=%s", traceId, idFuente));
                 return;
             }
+            if (esVacio(fuente.getConsulta())) {
+                agregarMsgWarn("La fuente externa no tiene consulta configurada.", null);
+                LOGGER.warn(String.format("[%s] Consulta vacía para fuente id=%s", traceId, idFuente));
+                return;
+            }
+            LOGGER.info(String.format("[%s] Fuente obtenida. id=%s, nombre=%s, servidor=%s, usuario=%s, alias=%s, base=%s, consultaLen=%d, consultaPreview=%s",
+                    traceId, fuente.getId(), fuente.getNombre(), enmascararServidor(fuente.getServidor()),
+                    esVacio(fuente.getUsuario()) ? "N/A" : fuente.getUsuario(),
+                    esVacio(fuente.getAlias()) ? "N/A" : fuente.getAlias(),
+                    esVacio(fuente.getNombreBaseDatos()) ? "N/A" : fuente.getNombreBaseDatos(),
+                    fuente.getConsulta() != null ? fuente.getConsulta().length() : 0,
+                    truncar(fuente.getConsulta(), 200)));
 
             String consultaNormalizada = normalizarConsulta(fuente.getConsulta());
             if (consultaNormalizada == null) {
+                int numInterrogaciones = contarOcurrencias(fuente.getConsulta(), "?");
+                int numMatricula = contarOcurrenciasIgnoreCase(fuente.getConsulta(), ":matricula");
+                int numUsuario = contarOcurrenciasIgnoreCase(fuente.getConsulta(), ":usuario");
+                LOGGER.warn(String.format(
+                        "[%s] Consulta inválida. Parámetros encontrados -> ?: %d, :matricula: %d, :usuario: %d",
+                        traceId, numInterrogaciones, numMatricula, numUsuario));
                 agregarMsgWarn("Configurar correctamente los datos de la fuente externa", null);
                 return;
             }
+            LOGGER.info(String.format("[%s] Consulta normalizada lista. Preview=%s", traceId,
+                    truncar(consultaNormalizada, 200)));
 
             try (Connection conexion = crearConexion(fuente)) {
                 if (conexion == null) {
-                    agregarMsgError("No fue posible establecer conexión con la fuente externa.", null);
+                    agregarMsgError("No se pudo construir la conexión con la fuente externa.", null);
+                    LOGGER.warn(String.format("[%s] No se pudo construir la conexión (servidor vacío).", traceId));
                     return;
                 }
+                String urlConexion = construirUrlConexion(fuente);
+                LOGGER.info(String.format("[%s] Conexión creada. url=%s, userPresent=%s, passwordPresent=%s, passwordLength=%d",
+                        traceId, enmascararServidor(urlConexion), !esVacio(fuente.getUsuario()),
+                        fuente.getContrasena() != null, fuente.getContrasena() != null ? fuente.getContrasena().length() : 0));
                 try (PreparedStatement ps = conexion.prepareStatement(consultaNormalizada)) {
                     ps.setString(1, matriculaImportar.trim());
+                    LOGGER.info(String.format("[%s] Ejecutando consulta. SQL=%s, parametro1=%s", traceId,
+                            truncar(consultaNormalizada, 200), matriculaImportar.trim()));
                     try (ResultSet rs = ps.executeQuery()) {
                         if (!rs.next()) {
                             agregarMsgWarn("No se encontró información para la matrícula especificada.", null);
+                            LOGGER.warn(String.format("[%s] ResultSet vacío para matrícula %s", traceId,
+                                    matriculaImportar.trim()));
                             return;
                         }
+                        LOGGER.info(String.format("[%s] ResultSet con datos. Columnas=%s", traceId,
+                                obtenerColumnas(rs)));
                         PersonaSigeDTO personaSige = mapearPersonaSige(rs);
                         if (ObjectUtils.isNull(personaSige) || esVacio(personaSige.getMatricula())) {
                             agregarMsgWarn("Configurar correctamente los datos de la fuente externa", null);
+                            LOGGER.warn(String.format("[%s] PersonaSige mapeada sin matrícula.", traceId));
                             return;
                         }
-                        guardarPersonaSige(personaSige);
+                        LOGGER.info(String.format(
+                                "[%s] Persona mapeada. Matricula=%s, Nombre=%s, Apellidos=%s %s, Correo=%s", traceId,
+                                personaSige.getMatricula(), personaSige.getNombre(),
+                                personaSige.getApellidoPaterno(), personaSige.getApellidoMaterno(),
+                                personaSige.getCorreoInstitucional()));
+                        guardarPersonaSige(personaSige, traceId);
                         matriculaNuevaAlta = personaSige.getMatricula();
                         agregarMsgInfo("Información importada correctamente", null);
+                        LOGGER.info(String.format("[%s] Importación exitosa para matrícula %s", traceId,
+                                matriculaNuevaAlta));
                     }
                 }
             }
@@ -421,22 +468,13 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
         if (totalParametros != 1) {
             return null;
         }
-        String consultaNormalizada = consulta.replaceAll("(?i):matricula", "?").replaceAll("(?i):usuario", "?");
-        return consultaNormalizada;
+        return consulta.replaceAll("(?i):matricula", "?").replaceAll("(?i):usuario", "?");
     }
 
     private Connection crearConexion(FuenteExternaDTO fuente) throws SQLException {
-        String url = fuente.getServidor();
-        if (ObjectUtils.isNull(url) || url.trim().isEmpty()) {
+        String url = construirUrlConexion(fuente);
+        if (url == null) {
             return null;
-        }
-        if (!url.toLowerCase().startsWith("jdbc:")) {
-            StringBuilder urlBuilder = new StringBuilder("jdbc:mysql://");
-            urlBuilder.append(url.trim());
-            if (!esVacio(fuente.getNombreBaseDatos())) {
-                urlBuilder.append("/").append(fuente.getNombreBaseDatos().trim());
-            }
-            url = urlBuilder.toString();
         }
         Properties propiedades = new Properties();
         if (!esVacio(fuente.getUsuario())) {
@@ -515,12 +553,66 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
         return false;
     }
 
-    private void guardarPersonaSige(PersonaSigeDTO personaSige) {
+    private String obtenerColumnas(ResultSet rs) throws SQLException {
+        ResultSetMetaData metaData = rs.getMetaData();
+        int columnas = metaData.getColumnCount();
+        List<String> nombres = new ArrayList<>();
+        for (int i = 1; i <= columnas; i++) {
+            nombres.add(metaData.getColumnLabel(i));
+        }
+        return nombres.toString();
+    }
+
+    private String construirUrlConexion(FuenteExternaDTO fuente) {
+        String url = fuente.getServidor();
+        if (ObjectUtils.isNull(url) || url.trim().isEmpty()) {
+            return null;
+        }
+        if (!url.toLowerCase().startsWith("jdbc:")) {
+            StringBuilder urlBuilder = new StringBuilder("jdbc:mysql://");
+            urlBuilder.append(url.trim());
+            if (!esVacio(fuente.getNombreBaseDatos())) {
+                urlBuilder.append("/").append(fuente.getNombreBaseDatos().trim());
+            }
+            url = urlBuilder.toString();
+        }
+        return url;
+    }
+
+    private String truncar(String valor, int max) {
+        if (valor == null) {
+            return null;
+        }
+        return valor.length() > max ? valor.substring(0, max) + "..." : valor;
+    }
+
+    private String enmascararServidor(String url) {
+        if (esVacio(url)) {
+            return url;
+        }
+        try {
+            int idxParams = url.indexOf("?");
+            String sinParametros = idxParams > 0 ? url.substring(0, idxParams) : url;
+            int idxCred = sinParametros.indexOf("@");
+            if (idxCred > 0) {
+                sinParametros = sinParametros.substring(idxCred + 1);
+            }
+            return truncar(sinParametros, 200);
+        } catch (Exception e) {
+            return truncar(url, 200);
+        }
+    }
+
+    private void guardarPersonaSige(PersonaSigeDTO personaSige, String traceId) {
         PersonaSigeDTO existente = personaSigeService.buscarPorMatricula(personaSige.getMatricula());
         if (ObjectUtils.isNotNull(existente)) {
             personaSige.setIdPersonaSige(existente.getIdPersonaSige());
+            LOGGER.info(String.format("[%s] Actualizando persona SIGE existente para matrícula %s", traceId,
+                    personaSige.getMatricula()));
             manejarResultadoPersistencia(personaSigeService.actualizar(personaSige));
         } else {
+            LOGGER.info(String.format("[%s] Insertando nueva persona SIGE para matrícula %s", traceId,
+                    personaSige.getMatricula()));
             manejarResultadoPersistencia(personaSigeService.guardar(personaSige));
         }
     }
@@ -534,6 +626,10 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                 } else if (!esVacio(resultado.getMensaje())) {
                     mensaje = resultado.getMensaje();
                 }
+                LOGGER.error(String.format(
+                        "Fallo en persistencia SIGE. esCorrecto=%s, mensaje=%s, mensajes=%s, mensajeError=%s",
+                        resultado.esCorrecto(), resultado.getMensaje(), resultado.getMensajes(),
+                        resultado.getMensajeError()));
             }
             throw new RuntimeException(mensaje);
         }

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
@@ -116,7 +116,7 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
             Integer idFuente = parseEntero(fuenteExternaSeleccionada);
             if (ObjectUtils.isNull(idFuente)) {
                 mostrarDialogoError(obtenerTextoSistema(
-                        "gw.gestionescolar.altasbajas.nuevaAlta.modal.importacionCorrecta"));
+                        "gw.gestionescolar.altasbajas.nuevaAlta.modal.fuenteInvalida"));
                 LOGGER.warn(String.format("[%s] No se pudo parsear la fuente externa seleccionada: %s", traceId,
                         fuenteExternaSeleccionada));
                 return;

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
@@ -171,9 +171,10 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                                 obtenerColumnas(rs)));
                         PersonaSigeDTO personaSige = mapearPersonaSige(rs);
                         LOGGER.info(String.format(
-                                "[%s] Datos mapeo previo a validación de matrícula. Columnas=%s, username=%s, firstname=%s, lastname=%s, email=%s, password=%s, matriculaFinal=%s",
+                                "[%s] Datos mapeo previo a validación de matrícula. Columnas=%s, username=%s, firstname=%s, lastname=%s, email=%s, passwordPresent=%s, matriculaFinal=%s",
                                 traceId, obtenerColumnas(rs), obtenerString(rs, "username"), obtenerString(rs, "firstname"),
-                                obtenerString(rs, "lastname"), obtenerString(rs, "email"), obtenerString(rs, "password"),
+                                obtenerString(rs, "lastname"), obtenerString(rs, "email"),
+                                !esVacio(obtenerString(rs, "password")),
                                 ObjectUtils.isNull(personaSige) ? null : personaSige.getMatricula()));
                         if (ObjectUtils.isNull(personaSige) || esVacio(personaSige.getMatricula())) {
                             agregarMsgWarn(

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
@@ -44,7 +44,7 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
     private static final long serialVersionUID = 1L;
     private static final List<String> COLUMNAS_REQUERIDAS = Arrays.asList("matricula_sige", "password_sige",
-            "nombre_sige", "apellidop_sige", "apellidom_sige", "programa_sige", "division_sige",
+            "nombre_sige", "apellidop_sige", "apellidom_sige", "programa_educativo_sige", "division_sige",
             "correo_institucional_sige", "fecha_nacimiento_sige", "curp_sige", "nivel_sige", "persona_id_sige",
             "perfil_id_sige");
 
@@ -525,7 +525,7 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
         persona.setNombre(obtenerString(rs, "nombre_sige"));
         persona.setApellidoPaterno(obtenerString(rs, "apellidop_sige"));
         persona.setApellidoMaterno(obtenerString(rs, "apellidom_sige"));
-        persona.setProgramaEducativo(obtenerString(rs, "programa_sige"));
+        persona.setProgramaEducativo(obtenerString(rs, "programa_educativo_sige"));
         persona.setDivision(obtenerString(rs, "division_sige"));
         persona.setCorreoInstitucional(obtenerString(rs, "correo_institucional_sige"));
         persona.setFechaNacimiento(obtenerFecha(rs, "fecha_nacimiento_sige"));
@@ -626,7 +626,7 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
             faltantes.add("apellidom_sige");
         }
         if (esVacio(personaSige.getProgramaEducativo())) {
-            faltantes.add("programa_sige");
+            faltantes.add("programa_educativo_sige");
         }
         if (esVacio(personaSige.getDivision())) {
             faltantes.add("division_sige");

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
@@ -103,14 +103,14 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
             LOGGER.info(String.format("[%s] Iniciando importación. Matricula: %s, Fuente seleccionada: %s", traceId,
                     matriculaImportar != null ? matriculaImportar.trim() : null, fuenteExternaSeleccionada));
             if (esVacio(matriculaImportar) || esVacio(fuenteExternaSeleccionada)) {
-                agregarMsgWarn("Capture matrícula y seleccione fuente externa.", null);
+                mostrarDialogoValidacion("Capture matrícula y seleccione fuente externa.");
                 LOGGER.warn(String.format("[%s] Faltan datos de entrada para importar.", traceId));
                 return;
             }
 
             Integer idFuente = parseEntero(fuenteExternaSeleccionada);
             if (ObjectUtils.isNull(idFuente)) {
-                agregarMsgWarn("Fuente externa inválida.", null);
+                mostrarDialogoError("Fuente externa inválida.");
                 LOGGER.warn(String.format("[%s] No se pudo parsear la fuente externa seleccionada: %s", traceId,
                         fuenteExternaSeleccionada));
                 return;
@@ -119,12 +119,12 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
             FuenteExternaDTO fuente = personaServiceFacade.buscarFuenteExternaPorId(idFuente);
             if (ObjectUtils.isNull(fuente)) {
-                agregarMsgWarn("No se encontró la configuración de la fuente externa.", null);
+                mostrarDialogoError("No se encontró la configuración de la fuente externa.");
                 LOGGER.warn(String.format("[%s] Fuente externa no encontrada. idFuente=%s", traceId, idFuente));
                 return;
             }
             if (esVacio(fuente.getConsulta())) {
-                agregarMsgWarn("La fuente externa no tiene consulta configurada.", null);
+                mostrarDialogoError("La fuente externa no tiene consulta configurada.");
                 LOGGER.warn(String.format("[%s] Consulta vacía para fuente id=%s", traceId, idFuente));
                 return;
             }
@@ -144,7 +144,7 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                 LOGGER.warn(String.format(
                         "[%s] Consulta inválida. Parámetros encontrados -> ?: %d, :matricula: %d, :usuario: %d",
                         traceId, numInterrogaciones, numMatricula, numUsuario));
-                agregarMsgWarn("Configurar correctamente los datos de la fuente externa", null);
+                mostrarDialogoError("Configurar correctamente los datos de la fuente externa.");
                 return;
             }
             LOGGER.info(String.format("[%s] Consulta normalizada lista. Preview=%s", traceId,
@@ -152,7 +152,7 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
             try (Connection conexion = crearConexion(fuente)) {
                 if (conexion == null) {
-                    agregarMsgError("No se pudo construir la conexión con la fuente externa.", null);
+                    mostrarDialogoError("No se pudo construir la conexión con la fuente externa.");
                     LOGGER.warn(String.format("[%s] No se pudo construir la conexión (servidor vacío).", traceId));
                     return;
                 }
@@ -166,7 +166,7 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                             truncar(consultaNormalizada, 200), matriculaImportar.trim()));
                     try (ResultSet rs = ps.executeQuery()) {
                         if (!rs.next()) {
-                            agregarMsgWarn("No se encontró información para la matrícula especificada.", null);
+                            mostrarDialogoError("No se encontró información para la matrícula especificada.");
                             LOGGER.warn(String.format("[%s] ResultSet vacío para matrícula %s", traceId,
                                     matriculaImportar.trim()));
                             return;
@@ -177,8 +177,8 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                             LOGGER.warn(String.format(
                                     "[%s] ResultSet sin columnas requeridas. Faltantes=%s, Columnas=%s", traceId,
                                     columnasFaltantes, columnasActuales));
-                            agregarMsgWarn("La consulta de la fuente externa no incluye las columnas requeridas: "
-                                    + String.join(", ", columnasFaltantes), null);
+                            mostrarDialogoError("La consulta de la fuente externa no incluye las columnas requeridas: "
+                                    + String.join(", ", columnasFaltantes));
                             return;
                         }
                         LOGGER.info(String.format("[%s] ResultSet con datos. Columnas=%s", traceId,
@@ -189,9 +189,8 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                                 traceId, obtenerColumnas(rs), !esVacio(personaSige.getPassword()),
                                 ObjectUtils.isNull(personaSige) ? null : personaSige.getMatricula()));
                         if (ObjectUtils.isNull(personaSige) || esVacio(personaSige.getMatricula())) {
-                            agregarMsgWarn(
-                                    "La fuente externa no devolvió matrícula (se esperaba matricula_sige). Revise la consulta/mapeo.",
-                                    null);
+                            mostrarDialogoError(
+                                    "La fuente externa no devolvió matrícula (se esperaba matricula_sige). Revise la consulta/mapeo.");
                             LOGGER.warn(String.format("[%s] PersonaSige mapeada sin matrícula.", traceId));
                             return;
                         }
@@ -199,10 +198,8 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                         if (!camposFaltantes.isEmpty()) {
                             LOGGER.warn(String.format("[%s] PersonaSige con campos obligatorios vacíos. Faltantes=%s",
                                     traceId, camposFaltantes));
-                            agregarMsgWarn(
-                                    "La fuente externa devolvió campos obligatorios vacíos: "
-                                            + String.join(", ", camposFaltantes),
-                                    null);
+                            mostrarDialogoError("La fuente externa devolvió campos obligatorios vacíos: "
+                                    + String.join(", ", camposFaltantes));
                             return;
                         }
                         LOGGER.info(String.format(
@@ -212,7 +209,7 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                                 personaSige.getCorreoInstitucional()));
                         guardarPersonaSige(personaSige, traceId);
                         matriculaNuevaAlta = personaSige.getMatricula();
-                        agregarMsgInfo("Información importada correctamente", null);
+                        mostrarDialogoExito("Información importada correctamente.");
                         LOGGER.info(String.format("[%s] Importación exitosa para matrícula %s", traceId,
                                 matriculaNuevaAlta));
                     }
@@ -222,7 +219,7 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
             LOGGER.error("Error al importar datos desde fuente externa", e);
             String mensaje = ObjectUtils.isNullOrEmpty(e.getMessage()) ? "Error al importar datos desde fuente externa"
                     : e.getMessage();
-            agregarMsgError(mensaje, null);
+            mostrarDialogoError(mensaje);
         }
     }
 
@@ -863,6 +860,11 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
     private void mostrarDialogo(String widgetVar) {
         RequestContext.getCurrentInstance().execute("PF('" + widgetVar + "').show()");
+    }
+
+    private void mostrarDialogoValidacion(String mensaje) {
+        mensajeValidacionDialogo = mensaje;
+        mostrarDialogo("dlgNuevaAltaValidacion");
     }
 
     private void mostrarDialogoError(String mensaje) {

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
@@ -222,6 +222,8 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                                 personaSige.getCorreoInstitucional()));
                         guardarPersonaSige(personaSige, traceId);
                         matriculaNuevaAlta = personaSige.getMatricula();
+                        matriculaImportar = null;
+                        fuenteExternaSeleccionada = null;
                         mostrarDialogoExito(obtenerTextoSistema(
                                 "gw.gestionescolar.altasbajas.nuevaAlta.modal.importacionCorrecta"));
                         LOGGER.info(String.format("[%s] Importación exitosa para matrícula %s", traceId,

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
@@ -8,6 +8,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -169,8 +170,15 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                         LOGGER.info(String.format("[%s] ResultSet con datos. Columnas=%s", traceId,
                                 obtenerColumnas(rs)));
                         PersonaSigeDTO personaSige = mapearPersonaSige(rs);
+                        LOGGER.info(String.format(
+                                "[%s] Datos mapeo previo a validación de matrícula. Columnas=%s, username=%s, firstname=%s, lastname=%s, email=%s, password=%s, matriculaFinal=%s",
+                                traceId, obtenerColumnas(rs), obtenerString(rs, "username"), obtenerString(rs, "firstname"),
+                                obtenerString(rs, "lastname"), obtenerString(rs, "email"), obtenerString(rs, "password"),
+                                ObjectUtils.isNull(personaSige) ? null : personaSige.getMatricula()));
                         if (ObjectUtils.isNull(personaSige) || esVacio(personaSige.getMatricula())) {
-                            agregarMsgWarn("Configurar correctamente los datos de la fuente externa", null);
+                            agregarMsgWarn(
+                                    "La fuente externa no devolvió matrícula (se esperaba username). Revise la consulta/mapeo.",
+                                    null);
                             LOGGER.warn(String.format("[%s] PersonaSige mapeada sin matrícula.", traceId));
                             return;
                         }
@@ -489,14 +497,43 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
     private PersonaSigeDTO mapearPersonaSige(ResultSet rs) throws SQLException {
         PersonaSigeDTO persona = new PersonaSigeDTO();
-        persona.setMatricula(obtenerString(rs, "matricula", "matricula_sige"));
+        String matricula = obtenerString(rs, "matricula", "matricula_sige");
+        if (esVacio(matricula) && tieneColumna(rs, "username")) {
+            matricula = rs.getString("username");
+        }
+        persona.setMatricula(matricula);
+
         persona.setPassword(obtenerString(rs, "password", "password_sige"));
-        persona.setNombre(obtenerString(rs, "nombre", "nombre_sige"));
-        persona.setApellidoPaterno(obtenerString(rs, "apellido_paterno", "apellidop_sige"));
-        persona.setApellidoMaterno(obtenerString(rs, "apellido_materno", "apellidom_sige"));
+
+        String nombre = obtenerString(rs, "nombre", "nombre_sige");
+        if (esVacio(nombre) && tieneColumna(rs, "firstname")) {
+            nombre = rs.getString("firstname");
+        }
+        persona.setNombre(nombre);
+
+        String apellidoPaterno = obtenerString(rs, "apellido_paterno", "apellidop_sige");
+        String apellidoMaterno = obtenerString(rs, "apellido_materno", "apellidom_sige");
+        if (esVacio(apellidoPaterno) && esVacio(apellidoMaterno) && tieneColumna(rs, "lastname")) {
+            String lastname = rs.getString("lastname");
+            if (!esVacio(lastname)) {
+                String[] partes = lastname.trim().split("\\s+");
+                if (partes.length > 0) {
+                    apellidoPaterno = partes[0];
+                    if (partes.length > 1) {
+                        apellidoMaterno = String.join(" ", Arrays.copyOfRange(partes, 1, partes.length));
+                    }
+                }
+            }
+        }
+        persona.setApellidoPaterno(apellidoPaterno);
+        persona.setApellidoMaterno(apellidoMaterno);
         persona.setProgramaEducativo(obtenerString(rs, "programa_educativo", "programa_educativo_sige"));
         persona.setDivision(obtenerString(rs, "division", "division_sige"));
-        persona.setCorreoInstitucional(obtenerString(rs, "correo_institucional", "correo_institucional_sige"));
+        String correo = obtenerString(rs, "correo_institucional", "correo_institucional_sige");
+        if (esVacio(correo) && tieneColumna(rs, "email")) {
+            correo = rs.getString("email");
+        }
+        persona.setCorreoInstitucional(correo);
         persona.setFechaNacimiento(obtenerFecha(rs, "fecha_nacimiento", "fecha_nacimiento_sige"));
         persona.setCurp(obtenerString(rs, "curp", "curp_sige"));
         persona.setNivelSige(obtenerString(rs, "nivel", "nivel_sige"));

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
@@ -1,10 +1,17 @@
 package mx.gob.sedesol.gestorweb.beans.gestionescolar;
 
 import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 
 import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
@@ -17,12 +24,15 @@ import org.primefaces.context.RequestContext;
 import mx.gob.sedesol.basegestor.commons.constantes.ConstantesGestor;
 import mx.gob.sedesol.basegestor.commons.dto.admin.ParametroWSMoodleDTO;
 import mx.gob.sedesol.basegestor.commons.dto.admin.PersonaDTO;
+import mx.gob.sedesol.basegestor.commons.dto.admin.PersonaSigeDTO;
+import mx.gob.sedesol.basegestor.commons.dto.admin.FuenteExternaDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.EventoCapacitacionDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.GrupoDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.RelGrupoParticipanteDTO;
 import mx.gob.sedesol.basegestor.commons.dto.gestionescolar.SelectImportarDTO;
 import mx.gob.sedesol.basegestor.commons.utils.ObjectUtils;
 import mx.gob.sedesol.basegestor.service.impl.admin.PersonaServiceFacade;
+import mx.gob.sedesol.basegestor.service.admin.PersonaSigeService;
 import mx.gob.sedesol.basegestor.service.impl.gestionescolar.EventoCapacitacionServiceFacade;
 import mx.gob.sedesol.gestorweb.beans.acceso.BaseBean;
 
@@ -34,6 +44,9 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
     @ManagedProperty("#{personaServiceFacade}")
     private transient PersonaServiceFacade personaServiceFacade;
+
+    @ManagedProperty("#{personaSigeService}")
+    private transient PersonaSigeService personaSigeService;
 
     @ManagedProperty("#{eventoCapacitacionServiceFacade}")
     private transient EventoCapacitacionServiceFacade eventoCapacitacionServiceFacade;
@@ -49,6 +62,7 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
     private List<SelectImportarDTO> listaEventos;
     private List<SelectImportarDTO> listaGrupos;
 
+    private String matriculaImportar;
     private String matriculaNuevaAlta;
     private String fuenteExternaSeleccionada;
     private String planSeleccionado;
@@ -75,6 +89,60 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
         listaProgramas = new ArrayList<>();
         listaEventos = new ArrayList<>();
         listaGrupos = new ArrayList<>();
+    }
+
+    public void importarDesdeFuenteExterna() {
+        try {
+            if (esVacio(matriculaImportar) || esVacio(fuenteExternaSeleccionada)) {
+                agregarMsgWarn("Configurar correctamente los datos de la fuente externa", null);
+                return;
+            }
+
+            Integer idFuente = parseEntero(fuenteExternaSeleccionada);
+            if (ObjectUtils.isNull(idFuente)) {
+                agregarMsgWarn("Configurar correctamente los datos de la fuente externa", null);
+                return;
+            }
+
+            FuenteExternaDTO fuente = personaServiceFacade.buscarFuenteExternaPorId(idFuente);
+            if (ObjectUtils.isNull(fuente) || esVacio(fuente.getConsulta())) {
+                agregarMsgWarn("Configurar correctamente los datos de la fuente externa", null);
+                return;
+            }
+
+            String consultaNormalizada = normalizarConsulta(fuente.getConsulta());
+            if (consultaNormalizada == null) {
+                agregarMsgWarn("Configurar correctamente los datos de la fuente externa", null);
+                return;
+            }
+
+            try (Connection conexion = crearConexion(fuente)) {
+                if (conexion == null) {
+                    agregarMsgError("No fue posible establecer conexión con la fuente externa.", null);
+                    return;
+                }
+                try (PreparedStatement ps = conexion.prepareStatement(consultaNormalizada)) {
+                    ps.setString(1, matriculaImportar.trim());
+                    try (ResultSet rs = ps.executeQuery()) {
+                        if (!rs.next()) {
+                            agregarMsgWarn("No se encontró información para la matrícula especificada.", null);
+                            return;
+                        }
+                        PersonaSigeDTO personaSige = mapearPersonaSige(rs);
+                        if (ObjectUtils.isNull(personaSige) || esVacio(personaSige.getMatricula())) {
+                            agregarMsgWarn("Configurar correctamente los datos de la fuente externa", null);
+                            return;
+                        }
+                        guardarPersonaSige(personaSige);
+                        matriculaNuevaAlta = personaSige.getMatricula();
+                        agregarMsgInfo("Información importada correctamente", null);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error al importar datos desde fuente externa", e);
+            agregarMsgError(e.getMessage(), null);
+        }
     }
 
     public void onPlanChange() {
@@ -319,6 +387,123 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
         }
     }
 
+    private String normalizarConsulta(String consulta) {
+        if (consulta.contains("?")) {
+            return consulta;
+        }
+        if (consulta.toLowerCase().contains(":matricula")) {
+            return consulta.replaceAll("(?i):matricula", "?");
+        }
+        return null;
+    }
+
+    private Connection crearConexion(FuenteExternaDTO fuente) throws SQLException {
+        String url = fuente.getServidor();
+        if (ObjectUtils.isNull(url) || url.trim().isEmpty()) {
+            return null;
+        }
+        if (!url.toLowerCase().startsWith("jdbc:")) {
+            StringBuilder urlBuilder = new StringBuilder("jdbc:mysql://");
+            urlBuilder.append(url.trim());
+            if (!esVacio(fuente.getNombreBaseDatos())) {
+                urlBuilder.append("/").append(fuente.getNombreBaseDatos().trim());
+            }
+            url = urlBuilder.toString();
+        }
+        Properties propiedades = new Properties();
+        if (!esVacio(fuente.getUsuario())) {
+            propiedades.put("user", fuente.getUsuario());
+        }
+        String password = obtenerPassword(fuente.getAlias());
+        if (!esVacio(password)) {
+            propiedades.put("password", password);
+        }
+        return DriverManager.getConnection(url, propiedades);
+    }
+
+    private String obtenerPassword(String alias) {
+        if (esVacio(alias)) {
+            return null;
+        }
+        String porPropiedad = System.getProperty("fuente.externa." + alias + ".password");
+        if (!esVacio(porPropiedad)) {
+            return porPropiedad;
+        }
+        String porAmbiente = System.getenv("FUENTE_EXTERNA_" + alias.toUpperCase() + "_PASSWORD");
+        return porAmbiente;
+    }
+
+    private PersonaSigeDTO mapearPersonaSige(ResultSet rs) throws SQLException {
+        PersonaSigeDTO persona = new PersonaSigeDTO();
+        persona.setMatricula(obtenerString(rs, "matricula", "matricula_sige"));
+        persona.setPassword(obtenerString(rs, "password", "password_sige"));
+        persona.setNombre(obtenerString(rs, "nombre", "nombre_sige"));
+        persona.setApellidoPaterno(obtenerString(rs, "apellido_paterno", "apellidop_sige"));
+        persona.setApellidoMaterno(obtenerString(rs, "apellido_materno", "apellidom_sige"));
+        persona.setProgramaEducativo(obtenerString(rs, "programa_educativo", "programa_educativo_sige"));
+        persona.setDivision(obtenerString(rs, "division", "division_sige"));
+        persona.setCorreoInstitucional(obtenerString(rs, "correo_institucional", "correo_institucional_sige"));
+        persona.setFechaNacimiento(obtenerFecha(rs, "fecha_nacimiento", "fecha_nacimiento_sige"));
+        persona.setCurp(obtenerString(rs, "curp", "curp_sige"));
+        persona.setNivelSige(obtenerString(rs, "nivel", "nivel_sige"));
+        persona.setPersonaIdSige(obtenerEntero(rs, "persona_id", "persona_id_sige"));
+        persona.setPerfilIdSige(obtenerEntero(rs, "perfil_id", "perfil_id_sige"));
+        return persona;
+    }
+
+    private String obtenerString(ResultSet rs, String... columnas) throws SQLException {
+        for (String columna : columnas) {
+            if (tieneColumna(rs, columna)) {
+                return rs.getString(columna);
+            }
+        }
+        return null;
+    }
+
+    private Date obtenerFecha(ResultSet rs, String... columnas) throws SQLException {
+        for (String columna : columnas) {
+            if (tieneColumna(rs, columna)) {
+                java.sql.Date fecha = rs.getDate(columna);
+                return fecha != null ? new Date(fecha.getTime()) : null;
+            }
+        }
+        return null;
+    }
+
+    private int obtenerEntero(ResultSet rs, String... columnas) throws SQLException {
+        for (String columna : columnas) {
+            if (tieneColumna(rs, columna)) {
+                return rs.getInt(columna);
+            }
+        }
+        return 0;
+    }
+
+    private boolean tieneColumna(ResultSet rs, String columna) throws SQLException {
+        ResultSetMetaData metaData = rs.getMetaData();
+        int columnas = metaData.getColumnCount();
+        for (int i = 1; i <= columnas; i++) {
+            if (columna.equalsIgnoreCase(metaData.getColumnLabel(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void guardarPersonaSige(PersonaSigeDTO personaSige) {
+        PersonaSigeDTO existente = personaSigeService.buscarPorMatricula(personaSige.getMatricula());
+        if (ObjectUtils.isNotNull(existente)) {
+            personaSige.setIdPersonaSige(existente.getIdPersonaSige());
+            if (ObjectUtils.isNull(personaSigeService.actualizar(personaSige).getDto())) {
+                LOGGER.warn("No se pudo actualizar la información de la persona SIGE");
+            }
+        } else {
+            if (ObjectUtils.isNull(personaSigeService.guardar(personaSige).getDto())) {
+                LOGGER.warn("No se pudo guardar la información de la persona SIGE");
+            }
+        }
+    }
+
     public List<SelectImportarDTO> getListaFuentesExternas() {
         return listaFuentesExternas;
     }
@@ -357,6 +542,14 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
     public void setMatriculaNuevaAlta(String matriculaNuevaAlta) {
         this.matriculaNuevaAlta = matriculaNuevaAlta;
+    }
+
+    public String getMatriculaImportar() {
+        return matriculaImportar;
+    }
+
+    public void setMatriculaImportar(String matriculaImportar) {
+        this.matriculaImportar = matriculaImportar;
     }
 
     public String getFuenteExternaSeleccionada() {
@@ -437,6 +630,10 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
     public void setPersonaServiceFacade(PersonaServiceFacade personaServiceFacade) {
         this.personaServiceFacade = personaServiceFacade;
+    }
+
+    public void setPersonaSigeService(PersonaSigeService personaSigeService) {
+        this.personaSigeService = personaSigeService;
     }
 
     public void setEventoCapacitacionServiceFacade(

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
@@ -37,6 +37,7 @@ import mx.gob.sedesol.basegestor.service.impl.admin.PersonaServiceFacade;
 import mx.gob.sedesol.basegestor.service.admin.PersonaSigeService;
 import mx.gob.sedesol.basegestor.service.impl.gestionescolar.EventoCapacitacionServiceFacade;
 import mx.gob.sedesol.gestorweb.beans.acceso.BaseBean;
+import mx.gob.sedesol.gestorweb.sistema.SistemaBean;
 
 @ManagedBean
 @ViewScoped
@@ -56,6 +57,9 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
     @ManagedProperty("#{eventoCapacitacionServiceFacade}")
     private transient EventoCapacitacionServiceFacade eventoCapacitacionServiceFacade;
+
+    @ManagedProperty("#{sistema}")
+    private transient SistemaBean sistema;
 
     private static final Logger LOGGER = Logger.getLogger(NuevaAltaUsuariosBean.class);
 
@@ -103,14 +107,16 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
             LOGGER.info(String.format("[%s] Iniciando importación. Matricula: %s, Fuente seleccionada: %s", traceId,
                     matriculaImportar != null ? matriculaImportar.trim() : null, fuenteExternaSeleccionada));
             if (esVacio(matriculaImportar) || esVacio(fuenteExternaSeleccionada)) {
-                mostrarDialogoValidacion("Capture matrícula y seleccione fuente externa.");
+                mostrarDialogoValidacion(obtenerTextoSistema(
+                        "gw.gestionescolar.altasbajas.nuevaAlta.modal.capturarModalFuente"));
                 LOGGER.warn(String.format("[%s] Faltan datos de entrada para importar.", traceId));
                 return;
             }
 
             Integer idFuente = parseEntero(fuenteExternaSeleccionada);
             if (ObjectUtils.isNull(idFuente)) {
-                mostrarDialogoError("Fuente externa inválida.");
+                mostrarDialogoError(obtenerTextoSistema(
+                        "gw.gestionescolar.altasbajas.nuevaAlta.modal.importacionCorrecta"));
                 LOGGER.warn(String.format("[%s] No se pudo parsear la fuente externa seleccionada: %s", traceId,
                         fuenteExternaSeleccionada));
                 return;
@@ -119,12 +125,14 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
             FuenteExternaDTO fuente = personaServiceFacade.buscarFuenteExternaPorId(idFuente);
             if (ObjectUtils.isNull(fuente)) {
-                mostrarDialogoError("No se encontró la configuración de la fuente externa.");
+                mostrarDialogoError(obtenerTextoSistema(
+                        "gw.gestionescolar.altasbajas.nuevaAlta.modal.sinConfigFuenteExterna"));
                 LOGGER.warn(String.format("[%s] Fuente externa no encontrada. idFuente=%s", traceId, idFuente));
                 return;
             }
             if (esVacio(fuente.getConsulta())) {
-                mostrarDialogoError("La fuente externa no tiene consulta configurada.");
+                mostrarDialogoError(obtenerTextoSistema(
+                        "gw.gestionescolar.altasbajas.nuevaAlta.modal.sinConsultaConfig"));
                 LOGGER.warn(String.format("[%s] Consulta vacía para fuente id=%s", traceId, idFuente));
                 return;
             }
@@ -144,7 +152,8 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                 LOGGER.warn(String.format(
                         "[%s] Consulta inválida. Parámetros encontrados -> ?: %d, :matricula: %d, :usuario: %d",
                         traceId, numInterrogaciones, numMatricula, numUsuario));
-                mostrarDialogoError("Configurar correctamente los datos de la fuente externa.");
+                mostrarDialogoError(obtenerTextoSistema(
+                        "gw.gestionescolar.altasbajas.nuevaAlta.modal.configurarDatosFuente"));
                 return;
             }
             LOGGER.info(String.format("[%s] Consulta normalizada lista. Preview=%s", traceId,
@@ -152,7 +161,8 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
             try (Connection conexion = crearConexion(fuente)) {
                 if (conexion == null) {
-                    mostrarDialogoError("No se pudo construir la conexión con la fuente externa.");
+                    mostrarDialogoError(obtenerTextoSistema(
+                            "gw.gestionescolar.altasbajas.nuevaAlta.modal.sinConexionFuenteExterna"));
                     LOGGER.warn(String.format("[%s] No se pudo construir la conexión (servidor vacío).", traceId));
                     return;
                 }
@@ -166,7 +176,8 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                             truncar(consultaNormalizada, 200), matriculaImportar.trim()));
                     try (ResultSet rs = ps.executeQuery()) {
                         if (!rs.next()) {
-                            mostrarDialogoError("No se encontró información para la matrícula especificada.");
+                            mostrarDialogoError(obtenerTextoSistema(
+                                    "gw.gestionescolar.altasbajas.nuevaAlta.modal.matriculaNoEncontrada"));
                             LOGGER.warn(String.format("[%s] ResultSet vacío para matrícula %s", traceId,
                                     matriculaImportar.trim()));
                             return;
@@ -177,8 +188,9 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                             LOGGER.warn(String.format(
                                     "[%s] ResultSet sin columnas requeridas. Faltantes=%s, Columnas=%s", traceId,
                                     columnasFaltantes, columnasActuales));
-                            mostrarDialogoError("La consulta de la fuente externa no incluye las columnas requeridas: "
-                                    + String.join(", ", columnasFaltantes));
+                            mostrarDialogoError(obtenerTextoSistema(
+                                    "gw.gestionescolar.altasbajas.nuevaAlta.modal.consultaColumnasRequeridas")
+                                    + " " + String.join(", ", columnasFaltantes));
                             return;
                         }
                         LOGGER.info(String.format("[%s] ResultSet con datos. Columnas=%s", traceId,
@@ -189,8 +201,8 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                                 traceId, obtenerColumnas(rs), !esVacio(personaSige.getPassword()),
                                 ObjectUtils.isNull(personaSige) ? null : personaSige.getMatricula()));
                         if (ObjectUtils.isNull(personaSige) || esVacio(personaSige.getMatricula())) {
-                            mostrarDialogoError(
-                                    "La fuente externa no devolvió matrícula (se esperaba matricula_sige). Revise la consulta/mapeo.");
+                            mostrarDialogoError(obtenerTextoSistema(
+                                    "gw.gestionescolar.altasbajas.nuevaAlta.modal.sinMatriculaSige"));
                             LOGGER.warn(String.format("[%s] PersonaSige mapeada sin matrícula.", traceId));
                             return;
                         }
@@ -198,8 +210,9 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                         if (!camposFaltantes.isEmpty()) {
                             LOGGER.warn(String.format("[%s] PersonaSige con campos obligatorios vacíos. Faltantes=%s",
                                     traceId, camposFaltantes));
-                            mostrarDialogoError("La fuente externa devolvió campos obligatorios vacíos: "
-                                    + String.join(", ", camposFaltantes));
+                            mostrarDialogoError(obtenerTextoSistema(
+                                    "gw.gestionescolar.altasbajas.nuevaAlta.modal.camposObligatoriosVacios")
+                                    + " " + String.join(", ", camposFaltantes));
                             return;
                         }
                         LOGGER.info(String.format(
@@ -209,7 +222,8 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                                 personaSige.getCorreoInstitucional()));
                         guardarPersonaSige(personaSige, traceId);
                         matriculaNuevaAlta = personaSige.getMatricula();
-                        mostrarDialogoExito("Información importada correctamente.");
+                        mostrarDialogoExito(obtenerTextoSistema(
+                                "gw.gestionescolar.altasbajas.nuevaAlta.modal.importacionCorrecta"));
                         LOGGER.info(String.format("[%s] Importación exitosa para matrícula %s", traceId,
                                 matriculaNuevaAlta));
                     }
@@ -858,8 +872,16 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
         this.eventoCapacitacionServiceFacade = eventoCapacitacionServiceFacade;
     }
 
+    public void setSistema(SistemaBean sistema) {
+        this.sistema = sistema;
+    }
+
     private void mostrarDialogo(String widgetVar) {
         RequestContext.getCurrentInstance().execute("PF('" + widgetVar + "').show()");
+    }
+
+    private String obtenerTextoSistema(String clave) {
+        return sistema != null ? sistema.obtenerTexto(clave) : clave;
     }
 
     private void mostrarDialogoValidacion(String mensaje) {

--- a/codigoFuente/gestorWeb/src/main/resources/updates_R020_20102025.sql
+++ b/codigoFuente/gestorWeb/src/main/resources/updates_R020_20102025.sql
@@ -47,3 +47,61 @@ INSERT INTO des_sisi_gestor.tbl_textos_sistema
               2
        FROM des_sisi_gestor.tbl_funcionalidades f
        WHERE f.clave = 'ALT_BAJ_USR';
+
+
+-- Modales del formulario Importar fuentes externas
+
+INSERT INTO des_sisi_gestor.tbl_textos_sistema (clave, valor, id_funcionalidad, fecha_registro, fecha_actualizacion, usuario_modifico)
+   SELECT 'gw.gestionescolar.altasbajas.nuevaAlta.modal.capturarModalFuente', 'Capture matrícula y seleccione fuente externa.', f.id_funcionalidad, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 2
+   FROM des_sisi_gestor.tbl_funcionalidades f
+   WHERE f.clave = 'ALT_BAJ_USR_ALT';
+
+INSERT INTO des_sisi_gestor.tbl_textos_sistema (clave, valor, id_funcionalidad, fecha_registro, fecha_actualizacion, usuario_modifico)
+   SELECT 'gw.gestionescolar.altasbajas.nuevaAlta.modal.matriculaNoEncontrada', 'No se encontró información para la matrícula especificada.', f.id_funcionalidad, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 2
+   FROM des_sisi_gestor.tbl_funcionalidades f
+   WHERE f.clave = 'ALT_BAJ_USR_ALT';
+
+INSERT INTO des_sisi_gestor.tbl_textos_sistema (clave, valor, id_funcionalidad, fecha_registro, fecha_actualizacion, usuario_modifico)
+   SELECT 'gw.gestionescolar.altasbajas.nuevaAlta.modal.importacionCorrecta', 'Información importada correctamente.', f.id_funcionalidad, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 2
+   FROM des_sisi_gestor.tbl_funcionalidades f
+   WHERE f.clave = 'ALT_BAJ_USR_ALT';
+
+INSERT INTO des_sisi_gestor.tbl_textos_sistema (clave, valor, id_funcionalidad, fecha_registro, fecha_actualizacion, usuario_modifico)
+   SELECT 'gw.gestionescolar.altasbajas.nuevaAlta.modal.camposObligatoriosVacios', 'La fuente externa devolvió campos obligatorios vacíos:', f.id_funcionalidad, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 2
+   FROM des_sisi_gestor.tbl_funcionalidades f
+   WHERE f.clave = 'ALT_BAJ_USR_ALT';
+
+INSERT INTO des_sisi_gestor.tbl_textos_sistema (clave, valor, id_funcionalidad, fecha_registro, fecha_actualizacion, usuario_modifico)
+   SELECT 'gw.gestionescolar.altasbajas.nuevaAlta.modal.consultaColumnasRequeridas', 'La consulta de la fuente externa no incluye las columnas requeridas:', f.id_funcionalidad, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 2
+   FROM des_sisi_gestor.tbl_funcionalidades f
+   WHERE f.clave = 'ALT_BAJ_USR_ALT';
+
+INSERT INTO des_sisi_gestor.tbl_textos_sistema (clave, valor, id_funcionalidad, fecha_registro, fecha_actualizacion, usuario_modifico)
+   SELECT 'gw.gestionescolar.altasbajas.nuevaAlta.modal.sinMatriculaSige', 'La fuente externa no devolvió matrícula (se esperaba matricula_sige). Revise la consulta/mapeo', f.id_funcionalidad, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 2
+   FROM des_sisi_gestor.tbl_funcionalidades f
+   WHERE f.clave = 'ALT_BAJ_USR_ALT';
+
+INSERT INTO des_sisi_gestor.tbl_textos_sistema (clave, valor, id_funcionalidad, fecha_registro, fecha_actualizacion, usuario_modifico)
+   SELECT 'gw.gestionescolar.altasbajas.nuevaAlta.modal.fuenteInvalida', 'Fuente externa inválida.', f.id_funcionalidad, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 2
+   FROM des_sisi_gestor.tbl_funcionalidades f
+   WHERE f.clave = 'ALT_BAJ_USR_ALT';
+
+INSERT INTO des_sisi_gestor.tbl_textos_sistema (clave, valor, id_funcionalidad, fecha_registro, fecha_actualizacion, usuario_modifico)
+   SELECT 'gw.gestionescolar.altasbajas.nuevaAlta.modal.sinConfigFuenteExterna', 'No se encontró la configuración de la fuente externa.',f.id_funcionalidad, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,2
+   FROM des_sisi_gestor.tbl_funcionalidades f
+   WHERE f.clave = 'ALT_BAJ_USR_ALT';
+
+INSERT INTO des_sisi_gestor.tbl_textos_sistema (clave, valor, id_funcionalidad, fecha_registro, fecha_actualizacion, usuario_modifico)
+   SELECT 'gw.gestionescolar.altasbajas.nuevaAlta.modal.sinConsultaConfig', 'La fuente externa no tiene consulta configurada.', f.id_funcionalidad, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 2
+   FROM des_sisi_gestor.tbl_funcionalidades f
+   WHERE f.clave = 'ALT_BAJ_USR_ALT';
+
+INSERT INTO des_sisi_gestor.tbl_textos_sistema (clave, valor, id_funcionalidad, fecha_registro, fecha_actualizacion, usuario_modifico)
+   SELECT 'gw.gestionescolar.altasbajas.nuevaAlta.modal.configurarDatosFuente', 'Configurar correctamente los datos de la fuente externa.', f.id_funcionalidad, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 2
+   FROM des_sisi_gestor.tbl_funcionalidades f
+   WHERE f.clave = 'ALT_BAJ_USR_ALT';
+
+INSERT INTO des_sisi_gestor.tbl_textos_sistema (clave, valor, id_funcionalidad, fecha_registro, fecha_actualizacion, usuario_modifico)
+   SELECT 'gw.gestionescolar.altasbajas.nuevaAlta.modal.sinConexionFuenteExterna', 'No se pudo construir la conexión con la fuente externa.', f.id_funcionalidad, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 2
+   FROM des_sisi_gestor.tbl_funcionalidades f
+   WHERE f.clave = 'ALT_BAJ_USR_ALT';


### PR DESCRIPTION
## Summary
- wire the Nueva Alta import panel to a backing action that validates the configured source and runs parameterized queries
- add DTO, repository, and service support to read external source metadata and upsert imported personas into tbl_persona_sige
- reuse the imported matrícula when creating altas to keep the existing enrollment workflow intact

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69586826a578832fa138799522170e23)