### PR TITLE
Validar alias SIGE requeridos en importación

### DIFF
--- a/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
+++ b/codigoFuente/basegestor/src/main/java/mx/gob/sedesol/basegestor/service/impl/admin/PersonaSigeServiceImpl.java
@@ -2,7 +2,6 @@ package mx.gob.sedesol.basegestor.service.impl.admin;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
@@ -92,11 +91,11 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 	public ResultadoDTO<PersonaSigeDTO> guardar(PersonaSigeDTO dto) {
 		ResultadoDTO<PersonaSigeDTO> resultado = new ResultadoDTO<>();
 		try {
-			if (dto.getPersonaIdSige() <= 0) {
-				dto.setPersonaIdSige(0);
-			}
-			if (dto.getPerfilIdSige() <= 0) {
-				dto.setPerfilIdSige(0);
+			List<String> faltantes = validarCamposObligatorios(dto);
+			if (!faltantes.isEmpty()) {
+				resultado.setResultado(ResultadoTransaccionEnum.FALLIDO);
+				resultado.setMensaje("No se guardó: faltan campos obligatorios: " + String.join(", ", faltantes));
+				return resultado;
 			}
 			TblPersonaSige entidad = new TblPersonaSige();
 			copiarCamposImportacion(dto, entidad, true);
@@ -108,7 +107,12 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 		} catch (Exception e) {
 			logger.error("Error al guardar persona sige", e);
 			resultado.setResultado(ResultadoTransaccionEnum.FALLIDO);
-			resultado.setMensajeError(MensajesErrorEnum.ERROR_PERSISTENCIA_DATOS, e.getMessage());
+			String mensajeAmigable = obtenerMensajeCampoNulo(e);
+			if (mensajeAmigable != null) {
+				resultado.setMensaje(mensajeAmigable);
+			} else {
+				resultado.setMensajeError(MensajesErrorEnum.ERROR_PERSISTENCIA_DATOS, e.getMessage());
+			}
 		}
 		return resultado;
 	}
@@ -119,6 +123,12 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 			if (dto.getIdPersonaSige() == null) {
 				logger.info("DTO sin idPersonaSige, se realizará inserción en lugar de actualización.");
 				return guardar(dto);
+			}
+			List<String> faltantes = validarCamposObligatorios(dto);
+			if (!faltantes.isEmpty()) {
+				resultado.setResultado(ResultadoTransaccionEnum.FALLIDO);
+				resultado.setMensaje("No se actualizó: faltan campos obligatorios: " + String.join(", ", faltantes));
+				return resultado;
 			}
 			TblPersonaSige existente = personaSigeRepo.findOne(dto.getIdPersonaSige());
 			if (existente == null) {
@@ -135,7 +145,12 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 		} catch (Exception e) {
 			logger.error("Error al actualizar persona sige", e);
 			resultado.setResultado(ResultadoTransaccionEnum.FALLIDO);
-			resultado.setMensajeError(MensajesErrorEnum.ERROR_PERSISTENCIA_DATOS, e.getMessage());
+			String mensajeAmigable = obtenerMensajeCampoNulo(e);
+			if (mensajeAmigable != null) {
+				resultado.setMensaje(mensajeAmigable);
+			} else {
+				resultado.setMensajeError(MensajesErrorEnum.ERROR_PERSISTENCIA_DATOS, e.getMessage());
+			}
 		}
 		return resultado;
 	}
@@ -226,31 +241,88 @@ public class PersonaSigeServiceImpl extends ComunValidacionService<PersonaSigeDT
 		if (actualizarIdsSiempre || dto.getPerfilIdSige() > 0) {
 			entidad.setPerfilIdSige(dto.getPerfilIdSige());
 		}
-		aplicarDefaultsNoNulos(entidad);
 	}
 	
-	private void aplicarDefaultsNoNulos(TblPersonaSige entidad) {
-		if (entidad.getCurp() == null) {
-			entidad.setCurp("");
+	private List<String> validarCamposObligatorios(PersonaSigeDTO dto) {
+		List<String> faltantes = new ArrayList<>();
+		if (dto == null) {
+			faltantes.add("matricula");
+			faltantes.add("password");
+			faltantes.add("nombre");
+			faltantes.add("apellidoPaterno");
+			faltantes.add("apellidoMaterno");
+			faltantes.add("programaEducativo");
+			faltantes.add("division");
+			faltantes.add("correoInstitucional");
+			faltantes.add("fechaNacimiento");
+			faltantes.add("curp");
+			faltantes.add("nivelSige");
+			faltantes.add("personaIdSige");
+			faltantes.add("perfilIdSige");
+			return faltantes;
 		}
-		if (entidad.getProgramaEducativo() == null) {
-			entidad.setProgramaEducativo("");
+		if (esVacio(dto.getMatricula())) {
+			faltantes.add("matricula");
 		}
-		if (entidad.getDivision() == null) {
-			entidad.setDivision("");
+		if (esVacio(dto.getPassword())) {
+			faltantes.add("password");
 		}
-		if (entidad.getNivelSige() == null) {
-			entidad.setNivelSige("");
+		if (esVacio(dto.getNombre())) {
+			faltantes.add("nombre");
 		}
-		if (entidad.getFechaNacimiento() == null) {
-			entidad.setFechaNacimiento(new Date(0L));
+		if (esVacio(dto.getApellidoPaterno())) {
+			faltantes.add("apellidoPaterno");
 		}
-		if (entidad.getPersonaIdSige() <= 0) {
-			entidad.setPersonaIdSige(0);
+		if (esVacio(dto.getApellidoMaterno())) {
+			faltantes.add("apellidoMaterno");
 		}
-		if (entidad.getPerfilIdSige() <= 0) {
-			entidad.setPerfilIdSige(0);
+		if (esVacio(dto.getProgramaEducativo())) {
+			faltantes.add("programaEducativo");
 		}
+		if (esVacio(dto.getDivision())) {
+			faltantes.add("division");
+		}
+		if (esVacio(dto.getCorreoInstitucional())) {
+			faltantes.add("correoInstitucional");
+		}
+		if (dto.getFechaNacimiento() == null) {
+			faltantes.add("fechaNacimiento");
+		}
+		if (esVacio(dto.getCurp())) {
+			faltantes.add("curp");
+		}
+		if (esVacio(dto.getNivelSige())) {
+			faltantes.add("nivelSige");
+		}
+		if (dto.getPersonaIdSige() == null || dto.getPersonaIdSige() <= 0) {
+			faltantes.add("personaIdSige");
+		}
+		if (dto.getPerfilIdSige() == null || dto.getPerfilIdSige() <= 0) {
+			faltantes.add("perfilIdSige");
+		}
+		return faltantes;
+	}
+
+	private boolean esVacio(String valor) {
+		return valor == null || valor.trim().isEmpty();
+	}
+
+	private String obtenerMensajeCampoNulo(Exception e) {
+		Throwable causa = e;
+		while (causa != null) {
+			String mensaje = causa.getMessage();
+			if (mensaje != null && mensaje.contains("Column '") && mensaje.contains("cannot be null")) {
+				int inicio = mensaje.indexOf("Column '") + "Column '".length();
+				int fin = mensaje.indexOf("'", inicio);
+				if (fin > inicio) {
+					String campo = mensaje.substring(inicio, fin);
+					return "No se guardó: el campo requerido '" + campo
+							+ "' viene vacío. Revise la consulta de la fuente externa.";
+				}
+			}
+			causa = causa.getCause();
+		}
+		return null;
 	}
 	
 }

--- a/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
+++ b/codigoFuente/gestorWeb/src/main/java/mx/gob/sedesol/gestorweb/beans/gestionescolar/NuevaAltaUsuariosBean.java
@@ -43,6 +43,10 @@ import mx.gob.sedesol.gestorweb.beans.acceso.BaseBean;
 public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
     private static final long serialVersionUID = 1L;
+    private static final List<String> COLUMNAS_REQUERIDAS = Arrays.asList("matricula_sige", "password_sige",
+            "nombre_sige", "apellidop_sige", "apellidom_sige", "programa_sige", "division_sige",
+            "correo_institucional_sige", "fecha_nacimiento_sige", "curp_sige", "nivel_sige", "persona_id_sige",
+            "perfil_id_sige");
 
     @ManagedProperty("#{personaServiceFacade}")
     private transient PersonaServiceFacade personaServiceFacade;
@@ -167,20 +171,38 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
                                     matriculaImportar.trim()));
                             return;
                         }
+                        List<String> columnasFaltantes = validarColumnasRequeridas(rs);
+                        if (!columnasFaltantes.isEmpty()) {
+                            String columnasActuales = obtenerColumnas(rs);
+                            LOGGER.warn(String.format(
+                                    "[%s] ResultSet sin columnas requeridas. Faltantes=%s, Columnas=%s", traceId,
+                                    columnasFaltantes, columnasActuales));
+                            agregarMsgWarn("La consulta de la fuente externa no incluye las columnas requeridas: "
+                                    + String.join(", ", columnasFaltantes), null);
+                            return;
+                        }
                         LOGGER.info(String.format("[%s] ResultSet con datos. Columnas=%s", traceId,
                                 obtenerColumnas(rs)));
                         PersonaSigeDTO personaSige = mapearPersonaSige(rs);
                         LOGGER.info(String.format(
-                                "[%s] Datos mapeo previo a validación de matrícula. Columnas=%s, username=%s, firstname=%s, lastname=%s, email=%s, passwordPresent=%s, matriculaFinal=%s",
-                                traceId, obtenerColumnas(rs), obtenerString(rs, "username"), obtenerString(rs, "firstname"),
-                                obtenerString(rs, "lastname"), obtenerString(rs, "email"),
-                                !esVacio(obtenerString(rs, "password")),
+                                "[%s] Datos mapeo previo a validación de matrícula. Columnas=%s, passwordPresent=%s, matriculaFinal=%s",
+                                traceId, obtenerColumnas(rs), !esVacio(personaSige.getPassword()),
                                 ObjectUtils.isNull(personaSige) ? null : personaSige.getMatricula()));
                         if (ObjectUtils.isNull(personaSige) || esVacio(personaSige.getMatricula())) {
                             agregarMsgWarn(
-                                    "La fuente externa no devolvió matrícula (se esperaba username). Revise la consulta/mapeo.",
+                                    "La fuente externa no devolvió matrícula (se esperaba matricula_sige). Revise la consulta/mapeo.",
                                     null);
                             LOGGER.warn(String.format("[%s] PersonaSige mapeada sin matrícula.", traceId));
+                            return;
+                        }
+                        List<String> camposFaltantes = validarCamposObligatorios(personaSige);
+                        if (!camposFaltantes.isEmpty()) {
+                            LOGGER.warn(String.format("[%s] PersonaSige con campos obligatorios vacíos. Faltantes=%s",
+                                    traceId, camposFaltantes));
+                            agregarMsgWarn(
+                                    "La fuente externa devolvió campos obligatorios vacíos: "
+                                            + String.join(", ", camposFaltantes),
+                                    null);
                             return;
                         }
                         LOGGER.info(String.format(
@@ -498,48 +520,19 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
 
     private PersonaSigeDTO mapearPersonaSige(ResultSet rs) throws SQLException {
         PersonaSigeDTO persona = new PersonaSigeDTO();
-        String matricula = obtenerString(rs, "matricula", "matricula_sige");
-        if (esVacio(matricula) && tieneColumna(rs, "username")) {
-            matricula = rs.getString("username");
-        }
-        persona.setMatricula(matricula);
-
-        persona.setPassword(obtenerString(rs, "password", "password_sige"));
-
-        String nombre = obtenerString(rs, "nombre", "nombre_sige");
-        if (esVacio(nombre) && tieneColumna(rs, "firstname")) {
-            nombre = rs.getString("firstname");
-        }
-        persona.setNombre(nombre);
-
-        String apellidoPaterno = obtenerString(rs, "apellido_paterno", "apellidop_sige");
-        String apellidoMaterno = obtenerString(rs, "apellido_materno", "apellidom_sige");
-        if (esVacio(apellidoPaterno) && esVacio(apellidoMaterno) && tieneColumna(rs, "lastname")) {
-            String lastname = rs.getString("lastname");
-            if (!esVacio(lastname)) {
-                String[] partes = lastname.trim().split("\\s+");
-                if (partes.length > 0) {
-                    apellidoPaterno = partes[0];
-                    if (partes.length > 1) {
-                        apellidoMaterno = String.join(" ", Arrays.copyOfRange(partes, 1, partes.length));
-                    }
-                }
-            }
-        }
-        persona.setApellidoPaterno(apellidoPaterno);
-        persona.setApellidoMaterno(apellidoMaterno);
-        persona.setProgramaEducativo(obtenerString(rs, "programa_educativo", "programa_educativo_sige"));
-        persona.setDivision(obtenerString(rs, "division", "division_sige"));
-        String correo = obtenerString(rs, "correo_institucional", "correo_institucional_sige");
-        if (esVacio(correo) && tieneColumna(rs, "email")) {
-            correo = rs.getString("email");
-        }
-        persona.setCorreoInstitucional(correo);
-        persona.setFechaNacimiento(obtenerFecha(rs, "fecha_nacimiento", "fecha_nacimiento_sige"));
-        persona.setCurp(obtenerString(rs, "curp", "curp_sige"));
-        persona.setNivelSige(obtenerString(rs, "nivel", "nivel_sige"));
-        Integer personaId = obtenerEntero(rs, "persona_id", "persona_id_sige");
-        Integer perfilId = obtenerEntero(rs, "perfil_id", "perfil_id_sige");
+        persona.setMatricula(obtenerString(rs, "matricula_sige"));
+        persona.setPassword(obtenerString(rs, "password_sige"));
+        persona.setNombre(obtenerString(rs, "nombre_sige"));
+        persona.setApellidoPaterno(obtenerString(rs, "apellidop_sige"));
+        persona.setApellidoMaterno(obtenerString(rs, "apellidom_sige"));
+        persona.setProgramaEducativo(obtenerString(rs, "programa_sige"));
+        persona.setDivision(obtenerString(rs, "division_sige"));
+        persona.setCorreoInstitucional(obtenerString(rs, "correo_institucional_sige"));
+        persona.setFechaNacimiento(obtenerFecha(rs, "fecha_nacimiento_sige"));
+        persona.setCurp(obtenerString(rs, "curp_sige"));
+        persona.setNivelSige(obtenerString(rs, "nivel_sige"));
+        Integer personaId = obtenerEntero(rs, "persona_id_sige");
+        Integer perfilId = obtenerEntero(rs, "perfil_id_sige");
         if (personaId != null) {
             persona.setPersonaIdSige(personaId);
         }
@@ -599,6 +592,64 @@ public class NuevaAltaUsuariosBean extends BaseBean implements Serializable {
             nombres.add(metaData.getColumnLabel(i));
         }
         return nombres.toString();
+    }
+
+    private List<String> validarColumnasRequeridas(ResultSet rs) throws SQLException {
+        List<String> faltantes = new ArrayList<>();
+        for (String columna : COLUMNAS_REQUERIDAS) {
+            if (!tieneColumna(rs, columna)) {
+                faltantes.add(columna);
+            }
+        }
+        return faltantes;
+    }
+
+    private List<String> validarCamposObligatorios(PersonaSigeDTO personaSige) {
+        List<String> faltantes = new ArrayList<>();
+        if (ObjectUtils.isNull(personaSige)) {
+            faltantes.addAll(COLUMNAS_REQUERIDAS);
+            return faltantes;
+        }
+        if (esVacio(personaSige.getMatricula())) {
+            faltantes.add("matricula_sige");
+        }
+        if (esVacio(personaSige.getPassword())) {
+            faltantes.add("password_sige");
+        }
+        if (esVacio(personaSige.getNombre())) {
+            faltantes.add("nombre_sige");
+        }
+        if (esVacio(personaSige.getApellidoPaterno())) {
+            faltantes.add("apellidop_sige");
+        }
+        if (esVacio(personaSige.getApellidoMaterno())) {
+            faltantes.add("apellidom_sige");
+        }
+        if (esVacio(personaSige.getProgramaEducativo())) {
+            faltantes.add("programa_sige");
+        }
+        if (esVacio(personaSige.getDivision())) {
+            faltantes.add("division_sige");
+        }
+        if (esVacio(personaSige.getCorreoInstitucional())) {
+            faltantes.add("correo_institucional_sige");
+        }
+        if (ObjectUtils.isNull(personaSige.getFechaNacimiento())) {
+            faltantes.add("fecha_nacimiento_sige");
+        }
+        if (esVacio(personaSige.getCurp())) {
+            faltantes.add("curp_sige");
+        }
+        if (esVacio(personaSige.getNivelSige())) {
+            faltantes.add("nivel_sige");
+        }
+        if (ObjectUtils.isNull(personaSige.getPersonaIdSige())) {
+            faltantes.add("persona_id_sige");
+        }
+        if (ObjectUtils.isNull(personaSige.getPerfilIdSige())) {
+            faltantes.add("perfil_id_sige");
+        }
+        return faltantes;
     }
 
     private String construirUrlConexion(FuenteExternaDTO fuente) {


### PR DESCRIPTION
### Motivation
- La fuente externa puede cambiar tablas/columnas por lo que el mapeo debe basarse exclusivamente en alias con sufijo `_sige`.
- Es necesario validar que la consulta de la fuente devuelva todas las columnas `_sige` requeridas antes de mapear o persistir.
- Evitar persistir registros incompletos y proporcionar retroalimentación clara al usuario y registros de backend con `traceId`.

### Description
- Se agregó la constante `COLUMNAS_REQUERIDAS` y el método `validarColumnasRequeridas(ResultSet)` para comprobar que el `ResultSet` incluya todos los alias requeridos antes del mapeo.
- Se modificó `mapearPersonaSige` para usar exclusivamente alias `*_sige` y se eliminaron los fallbacks a columnas como `username`, `firstname`, `lastname` o `email`.
- Se añadió `validarCamposObligatorios(PersonaSigeDTO)` y se valida antes de llamar a la persistencia, mostrando mensajes user-friendly con `agregarMsgWarn` cuando falten campos.
- Se actualizó el logging previo al guardado para no exponer contraseñas y registrar únicamente la presencia de contraseña mediante booleanos.

### Testing
- No se ejecutaron pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696485d70960832fb978b51fdf57baef)